### PR TITLE
🚀 Pull Request: Graph Construction Pipeline Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ For any questions or support, please contact:
 
 ## 📝 Citation
 
+SoftwareX paper: [here](https://www.sciencedirect.com/science/article/pii/S2352711025000883).
+
 Please cite us if you use the library
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14039358.svg)](https://zenodo.org/doi/10.5281/zenodo.14039358)
@@ -268,7 +270,7 @@ This work was carried out within European projects:
 Moderate - Horizon Europe research and innovation programme under grant agreement No 101069834, with the aim of contributing to the development of open products useful for defining plausible scenarios for the decarbonization of the built environment
 BrickLLM is developed and maintained by the Energy Efficiency in Buildings group at EURAC Research. Thanks to the contribution of:
 - Moderate project: Horizon Europe research and innovation programme under grant agreement No 101069834
-- Politecnico of Turin, in particular to @Rocco Giudice for his work in developing model generation using local language model
+- Politecnico of Turin, in particular to Rocco Giudice, Marco Savino Piscitelli and Alfonso Capozzoli from BAEDALab.
 
 -----------------------------
-Thank you to [**Brick**](https://brickschema.org/) for the great work it is doing
+Thank you to [**Brick**](https://brickschema.org/) for the great work it is doing.

--- a/brickllm/__init__.py
+++ b/brickllm/__init__.py
@@ -6,6 +6,9 @@ from .schemas import (
     SensorSchema,
     TTLSchema,
     TTLToBuildingPromptSchema,
+    EntityType,
+    Relationship,
+    TriplesSchema
 )
 from .states import State, StateLocal
 
@@ -19,4 +22,7 @@ __all__ = [
     "GraphConfig",
     "custom_logger",
     "SensorSchema",
+    "EntityType",
+    "Relationship",
+    "TriplesSchema"
 ]

--- a/brickllm/edges/validate_condition.py
+++ b/brickllm/edges/validate_condition.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Literal
 
 
-def validate_condition(state: Dict[str, Any]) -> Literal["schema_to_ttl", "__end__"]:
+def validate_condition(state: Dict[str, Any]) -> Literal["model_refactoring", "__end__"]:
     """
     Validate the condition for the next node to visit.
 
@@ -16,6 +16,6 @@ def validate_condition(state: Dict[str, Any]) -> Literal["schema_to_ttl", "__end
     max_iter = state.get("validation_max_iter", 0)
 
     if max_iter > 0 and not is_valid:
-        return "schema_to_ttl"
+        return "model_refactoring"
 
     return "__end__"

--- a/brickllm/helpers/__init__.py
+++ b/brickllm/helpers/__init__.py
@@ -8,6 +8,9 @@ from .prompts import (
     schema_to_ttl_instructions,
     ttl_example,
     ttl_to_user_prompt,
+    model_refactor_instructions,
+    find_entities_type,
+    find_relationship
 )
 
 __all__ = [
@@ -20,4 +23,7 @@ __all__ = [
     "prompt_template_local",
     "ttl_to_user_prompt",
     "get_sensors_instructions",
+    "model_refactor_instructions",
+    "find_entities_type",
+    "find_relationship"
 ]

--- a/brickllm/helpers/prompts.py
+++ b/brickllm/helpers/prompts.py
@@ -3,51 +3,101 @@ Module containing the prompts used for the LLM models
 """
 
 get_elem_instructions: str = """
-    You are an expert in indentifying semantic elements in a natural language prompt hich describes a building and/or energy systems.\n
-    You are provided with a dictionary containing the entities of an ontology (ELEMENTS) in a hierarchical way, which can be used to describe the building and/or the energy systems. 
-    You are also provided with the elements description to understand what each element represents.\n
-    You are now asked to identify the entities of the ENTITIES dictionary presented in the user prompt (USER PROMPT), choosing the most specific one if it is possible among the ones provided. Return the entities of ENTITIES (with the proper underscores) presented in the USER PROMPT.\n
-    USER PROMPT: {prompt} \n
-    ENTITIES: {elements_dict} \n
-    """  # noqa
+You are an expert in recognizing elements from a given ontology dictionary (ONTOLOGY) in a natural language description of a building and/or energy systems (DESCRIPTION).\n
+You are tasked with identifiying which elements of the ontology dictionary are present in the description.\n
+
+# Resources Provided:
+- ONTOLOGY: A hierarchical dictionary containing ontology entities with a description of each entity.
+
+{elements_dict}
+
+- DESCRIPTION: A natural language description of a building or energy systems.
+
+{user_prompt}
+
+# Your Objective:
+- Identify and return all the semantic elements from the ontology dictionary that are also present in the DESCRIPTION. If no elements are found, return an empty list.
+ """  # noqa
 
 get_elem_children_instructions: str = """
-    You are a semantic ontology expert and you are provided with a user prompt (USER PROMPT) which describes a building and/or energy systems.\n
+    You are a semantic ontology expert and you are provided with a description (DESCRIPTION) which describes a building and/or energy systems.\n
     You are provided with a list of common elements organized in a hierarchy (ELEMENTS HIERARCHY).\n
-    You are now asked to identify the elements in the hierarchy presents in the user prompt.\n
+    You are now asked to identify the elements in the hierarchy presents in the description.\n
     The elements provided are in the format of a hierarchy,
     eg: `Sensor -> Position_Sensor, Sensor -> Energy_Sensor`\n
-    You must include only the elements in the list of common elements provided.\n
+    You must include only the elements in the list of elements provided.\n
     DO NOT repeat any elements and DO NOT include "->" in your response.\n
 
-    USER PROMPT: {prompt} \n
+    DESCRIPTION: {prompt} \n
     ELEMENTS HIERARCHY: {elements_list} \n
     """  # noqa
 
 get_relationships_instructions: str = """
-    You are a semantic ontology expert and you are provided with a user prompt (USER PROMPT) that describes a building and/or energy systems.\n
-    You are also provided with a hierarchical structure (HIERARCHICAL STRUCTURE) of the identified building or energy systems components in the prompt.\n
-    Your task is to determine the relationships between these components based on the context within the building description and the provided hierarchical structure.\n
-    The relationships should reflect direct connections or associations as described or implied in the prompt.\n
-    Each element must be followed by a dot symbol (.) and a number to differentiate between elements of the same type (e.g., Room.1, Room.2).\n
-    An example of output is the following: [('Building.1', 'Floor.1'), ('Floor.1', 'Room.1'), ('Building.1','Floor.2'), ...]\n
-    DO NOT add relationships on the output but only the components names, always add first the parent and then the child.\n
-    If an element has no relationships, add an empty string in place of the missing component ("Room.1","").\n
-    HIERARCHICAL STRUCTURE: {building_structure}\n
-    USER PROMPT: {prompt}
+    You are a semantic ontology expert and you are provided with a description (DESCRIPTION) that describes a building and/or energy systems.\n
+    Your task is to determine the entities inside the description the relationships between these entities based on the context within the description.\n
+    The relationships should reflect direct connections or associations as described or implied in the description.\n
+    You must distinguish different entities of the same type, each entiity must be followed by a dot symbol (.) and a number to differentiate between enetities of the same type (e.g., Room.1, Room.2).\n
+    An example of output is the following: [('Building.1', 'Floor.1'), ('Floor.1', 'Room.1'), ('Room.1', 'Temperature_Sensor.1'), ('Room.1', 'Temperature_Sensor.2'), ...]\n
+    Ignore timeseries ID references.\n
+
+    DESCRIPTION: {prompt}
+    
 """  # noqa
 
+find_entities_type = """
+You are an expert in mapping ontology concepts (ONTOLOGY CONCEPTS) to entities extracted from a building or energy system description (DESCRIPTION).\n
+You are provided with the building or energy system description to have the context (DESCRIPTION).\n
+You are provided with the relationships you recognized between the entities in the descriptions (RELATIONSHIPS).\n
+You are provided with the hierarchy of the ontology concepts (ONTOLOGY CONCEPTS).\n
+Your job is to find the most appropriate ontology concept for an entity extracted from the building description. I will provide you with the name of an entitiy (ENTITY) and you have to find the related ontological concept, but only the most specific one form the hierarchy.\n
+
+DESCRIPTION: {user_prompt}\n
+
+RELATIONSHIPS: {relationships}\n
+
+ONTOLOGY CONCEPTS: {hierarchical_structure}\n
+
+Return only the most specific ontology concept from ONTOLOGY CONCEPTS hierarchy that better represent the ENTITY.\n
+ENTIIY: {entity}\n
+"""  # noqa
+
+find_relationship = """
+You are expert in extracting and linking semantic entities from a building or energy system description (DESCRIPTION) based on the constraints provided by an ontology.\n
+In particular, your task is to link the entities already extracted in form of tuples (TUPLE), assigning a relationship between them.\n
+You are provided with the description of the building or the energy system to have the context (DESCRIPTION).\n
+You are provided with a tuple that contains the two entities linked (TUPLE).\n
+You are also provided with a dictionary (RELATIONSHIPS) that contains the relationships admitted between the two entities. Each relationships is a dictionary where the key is the relationship and the value is the description.\n
+Based on the DESCRIPTION, the entities in the TUPLE and the RELATIONSHIPS, you have to find the most appropriate relationship between the two entities.\n
+Return only the relationship key that best fit the entities in the TUPLE.\n
+
+DESCRIPTION: {user_prompt}
+
+TUPLE: {tuple}
+
+RELATIONSHIPS: {relationships}
+
+Return only one relationship among RELATIONSHIPS that best link the entities in the TUPLE based on the context provided in the DESCRIPTION. Do not add any context to the response.\n
+"""
 
 get_sensors_instructions: str = """
-    You are an expert in identifying information in a natural language prompt (USER PROMPT) that describes a building and/or energy systems.\n
-    Your task is to map information about sensors in the building into the provided hierarchical sensor structure (HIERARCHICAL SENSOR STRUCTURE).\n
-    You must look in the USER PROMPT for finding the UUID of the sensors and their unit of measures, if provided. If these information ar not provided in the USER PROMPT, return the HIERARCHICAL SENSOR STRUCTURE as it is.\n
-    The UUID of the sensors may be explicitly provided in the USER PROMPT or may be inferred from the context (they may be in parentheses or brackets).\n
-    To encode the unit of measures, use the names defined by the QUDT ontology.\n
-    Complete the HIERARCHICAL SENSOR STRUCTURE with the "uuid" and "unit" fields for each sensor, if provided in the USER PROMPT.\n
-    Remember, only provide units and ID if explicitly provided in the user prompt! If those information are not provided, return the dictionary with the empty field.
-    USER PROMPT: {prompt}
-    HIERARCHICAL SENSOR STRUCTURE: {sensor_structure}
+    Your task is to complete a dictionary of sensors (SENSOR DICTIONARY) based on the information provided in a description of a building and/or energy systems (DESCRIPTION).\n
+    
+    DESCRIPTION:\n
+    {prompt}\n
+    
+    SENSOR DICTIONARY:\n
+    {sensor_structure}
+    
+    Your task is to identify in the DESCRIPTION either the identifier of the sensors (id) and/or their unit of measures (unit).\n
+    
+    For each sensor type, you can choose only between the unit of measures provided (UOM), choosing the most appropriate QUDT one for each type of sensor., if they are specified.\n
+    
+    UOM:\n
+    {unit_of_measures}
+    
+    Regarding the identifiers (id), they can be provided in parentheses or brackets. If the timeseries is not provided, leave None in the dictionary 'id' field.\n
+    Regarding the unit of measures, they can be provided in the description as a natural language. Return the most appropriate corresponding QUDT. If the unit of measure is not provided, leave None in the dictionary.\n
+    Do not include information that are not mentioned in the DESCRIPTION.
 """
 
 ttl_example: str = """
@@ -95,7 +145,9 @@ ttl_example: str = """
 schema_to_ttl_instructions: str = """
     You are an expert in generating ontology-based RDF graph from a user prompt, which describes a building or energy systems.\n
     You are provided with a dictionary containing the hierarchy of the building/energy systems components (COMPONENTS HIERARCHY) detected in the user prompt (USER PROMP).\n
+    You are also provided with the relationships between the components (RELATIONSHIPS) identified in the user prompt.\n
     You are also provided with the list of the sensors (SENSOR LIST) identified in the user prompts, with additional information about uuid and unit of measures, if avaiable.
+    
     Your task is to generate a RDF graph in Turtle format that is compliant with the hierarchy and relationships described in the input. Use only the elements identified in the COMPONENTS HIERARCHY and SENSOR LIST, connecting each entities with the appropriate properties (presented in each element of the hierarchy).\n
     DO NOT add information that are not present in the input.\n
     To encode the uuid of the sensors, use the following schema: 'sensor' ref:hasExternalReference [ a ref:TimeseriesReference ; ref:hasTimeseriesId 'uuid'^^xsd:string .].\n
@@ -103,13 +155,29 @@ schema_to_ttl_instructions: str = """
     Include all the @prefix declarations at the beginning of the output Turtle file.\n
     I provide you an example of the output Turtle: the TTL SCRIPT EXAMPLE is useful to understand the overall structure of the output, not the actual content. Do not copy any information from this example.\n
     TTL SCRIPT EXAMPLE: {ttl_example}\n
-
-    COMPONENTS HIERARCHY: {elem_hierarchy}\n
-
+    
+    # Inputs
     USER PROMPT: {prompt}\n
+    
+    COMPONENTS HIERARCHY: {elem_hierarchy}\n
 
     SENSOR LIST: {uuid_list}\n
 """  # noqa
+
+model_refactor_instructions: str = """
+    You are an expert in refactoring a RDF graph based on a validation report from the ontology and the natural language description of the RDF graph.\n
+    You are provided with the following inputs:
+    1. **RDF GRAPH**: The RDF graph generated from the user prompt that needs to be refactored.\n
+    {rdf_graph}
+    
+    2. **VALIDATION REPORT**: A SHACL shapes validation report that identifies the issues in the RDF graph generated from the description.\n
+    {validation_report}
+    
+    3: **DESCRIPTION**: The original description that was used to generate the RDF graph.\n
+    {user_prompt}
+    
+    Your task is to refactor the RDF graph. Ensure that the refactored RDF graph is consistent with the original description and the entities and relationship of the Brick ontology, addressing all the validation errors.\n
+"""
 
 ttl_to_user_prompt: str = """
     You are a BrickSchema ontology expert tasked with generating a clear and concise description of a building or facility from a TTL script.

--- a/brickllm/nodes/__init__.py
+++ b/brickllm/nodes/__init__.py
@@ -5,6 +5,7 @@ from .get_relationships import get_relationships
 from .get_sensors import get_sensors
 from .schema_to_ttl import schema_to_ttl
 from .validate_schema import validate_schema
+from .model_refactoring import model_refactoring
 
 __all__ = [
     "get_elem_children",
@@ -14,4 +15,5 @@ __all__ = [
     "schema_to_ttl",
     "validate_schema",
     "generation_local",
+    "model_refactoring",
 ]

--- a/brickllm/nodes/get_elem_children.py
+++ b/brickllm/nodes/get_elem_children.py
@@ -20,7 +20,7 @@ def get_elem_children(state: State, config: Dict[str, Any]) -> Dict[str, Any]:
         dict: A dictionary containing the hierarchical structure of identified elements.
     """
     custom_logger.eurac(
-        "📊 Getting children for each BrickSchema category in the element list"
+        "📊 Getting the Brick hierarchy for the identified elements."
     )
 
     user_prompt = state["user_prompt"]
@@ -66,6 +66,6 @@ def get_elem_children(state: State, config: Dict[str, Any]) -> Dict[str, Any]:
     filtered_children = filter_elements(identified_children)
 
     # create hierarchical dictionary
-    hierarchical_dict = create_hierarchical_dict(filtered_children, properties=True)
+    hierarchical_dict = create_hierarchical_dict(filtered_children, properties=False)
 
     return {"elem_hierarchy": hierarchical_dict}

--- a/brickllm/nodes/get_relationships.py
+++ b/brickllm/nodes/get_relationships.py
@@ -1,12 +1,24 @@
 import json
+import pkg_resources
+import os
 from typing import Any, Dict
 
 from langchain_core.messages import HumanMessage, SystemMessage
-
-from .. import RelationshipsSchema, State
-from ..helpers import get_relationships_instructions
+from rdflib import Graph, Namespace
+from .. import RelationshipsSchema, State, EntityType, Relationship
+from ..helpers import get_relationships_instructions, find_entities_type, find_relationship
 from ..logger import custom_logger
-from ..utils import build_hierarchy, find_sensor_paths
+from ..utils import find_rel_constraint, get_rel_definition, find_parents
+
+brick_hierarchy_path = pkg_resources.resource_filename(
+    __name__, os.path.join("..", "ontologies", "brick_hierarchy.json")
+)
+
+# Load the JSON file
+with open(brick_hierarchy_path) as f:
+    brick_hierarchy = json.load(f)
+
+MAX_RETRIES = 3
 
 
 def get_relationships(state: State, config: Dict[str, Any]) -> Dict[str, Any]:
@@ -20,13 +32,14 @@ def get_relationships(state: State, config: Dict[str, Any]) -> Dict[str, Any]:
     Returns:
         dict: A dictionary containing the grouped sensor paths.
     """
-    custom_logger.eurac("🔗 Getting relationships between building components")
+
+    custom_logger.eurac("🔗 Identifying related entities from the user prompt")
 
     user_prompt = state["user_prompt"]
-    building_structure = state["elem_hierarchy"]
+    hierarchical_structure = state["elem_hierarchy"]
 
     # Convert building structure to a JSON string for better readability
-    building_structure_json = json.dumps(building_structure, indent=2)
+    hierarchical_structure_json = json.dumps(hierarchical_structure, indent=2)
 
     # Get the model name from the config
     llm = config.get("configurable", {}).get("llm_model")
@@ -35,32 +48,161 @@ def get_relationships(state: State, config: Dict[str, Any]) -> Dict[str, Any]:
     structured_llm = llm.with_structured_output(RelationshipsSchema)
     # System message
     system_message = get_relationships_instructions.format(
-        prompt=user_prompt, building_structure=building_structure_json
+        prompt=user_prompt
     )
 
-    # Generate question
     answer = structured_llm.invoke(
         [SystemMessage(content=system_message)]
-        + [HumanMessage(content="Find the relationships.")]
     )
 
-    try:
-        tree_dict = build_hierarchy(answer.relationships)
-    except Exception:
-        custom_logger.warning("Error building the hierarchy. Trying again.")
+    # Check the format of the entities in order to not break the graph.
+    relationships = []
+    for relationship in answer.relationships:
+        relationships.append((relationship[0].replace(" ", "_"), (relationship[1].replace(" ", "_"))))
 
-    # Group sensors by their paths
-    sensor_paths = []
-    for root_node in tree_dict:
-        sensor_paths.extend(find_sensor_paths(tree_dict[root_node]))
+    # Build the skeleton of the entities as a dict
+    entities_dict = {}
+    for relationship in relationships:
+        if relationship[0] not in entities_dict and relationship[0] != "":
+            entities_dict[relationship[0]] = {
+                "name": relationship[0],
+                "type": None
+            }
 
-    grouped_sensors = {}
+        if relationship[1] not in entities_dict and relationship[1] != "":
+            entities_dict[relationship[1]] = {
+                "name": relationship[1],
+                "type": None
+            }
 
-    for sensor in sensor_paths:
-        grouped_sensors[sensor["name"]] = {
-            "name": sensor["name"],
-            "uuid": None,
-            "unit": None,
-        }
+    # Obtain all Brick entities to check if the entity type that will be identified is true
+    def extract_keys(data, keys=None):
+        if keys is None:
+            keys = []
 
-    return {"rel_tree": tree_dict, "sensors_dict": grouped_sensors}
+        for key, value in data.items():
+            keys.append(key)
+            if isinstance(value, dict):  # If the value is a nested dictionary, recurse
+                extract_keys(value, keys)
+
+        return keys
+
+    all_brick_entities = extract_keys(brick_hierarchy)
+
+    custom_logger.eurac("🔗 Identifying entity types")
+
+    for entity in entities_dict:
+        system_message = find_entities_type.format(
+            user_prompt=user_prompt,
+            hierarchical_structure=hierarchical_structure_json,
+            entity=entity,
+            relationships=relationships
+        )
+
+        structured_llm = llm.with_structured_output(EntityType)
+
+        for attempt in range(MAX_RETRIES):
+            answer = structured_llm.invoke([SystemMessage(content=system_message)])
+            concept = answer.ontology_concept
+
+            if concept == entity:
+                entity_type = concept.split(".")[0]
+            elif "." in concept:
+                entity_type = concept.split(".")[-1]
+            elif concept not in all_brick_entities:
+                custom_logger.warning(f"Entity not recognized (attempt {attempt + 1}). Retrying...")
+                continue
+            else:
+                entity_type = concept
+            break
+        else:
+            # Fallback if all retries failed
+            custom_logger.warning(f"Max retries reached for entity: {entity}. Using fallback type.")
+            entity_type = entity.split(".")[0]
+
+        entities_dict[entity]["type"] = entity_type
+
+    # Adding the possible relationships for each entity extracted by the Brick ontology
+    for entity in entities_dict:
+        try:
+            entities_dict[entity]["relationships"] = find_rel_constraint(entities_dict[entity]["type"])
+        except Exception:
+            # Drop the entity if it does not have a type
+            print("Type not recognized for entity: ", entity)
+
+    # Extract the super classes for each entity from the Brick ontology
+    for entity in entities_dict:
+        super_classes = find_parents(brick_hierarchy, entities_dict[entity]["type"])[1]
+        entities_dict[entity]["super_classes"] = super_classes
+
+    custom_logger.eurac("🔗 Getting relationships between building components")
+
+    triples = []
+    for relationship in relationships:
+
+        subject = relationship[0]
+        object = relationship[1]
+
+        all_relationships = entities_dict[subject]["relationships"]
+        object_type = entities_dict[object]["type"]
+        object_superclasses = entities_dict[object]["super_classes"]
+        object_constraint = [object_type] + object_superclasses
+
+        # Extract the relationships that are valid for the entity type and its super classes
+        valid_relationships = {}
+        for rel_type in all_relationships:
+            if any([constraint in all_relationships[rel_type]["constraints"] for constraint in object_constraint]):
+                valid_relationships[rel_type] = all_relationships[rel_type]["definition"]
+
+        if len(valid_relationships.keys()) == 0:
+            valid_relationships = get_rel_definition()
+
+        system_message = find_relationship.format(
+            user_prompt=user_prompt,
+            tuple=(subject, object),
+            relationships=valid_relationships
+        )
+
+        structured_llm = llm.with_structured_output(Relationship)
+
+        answer = structured_llm.invoke(
+            [SystemMessage(content=system_message)]
+            + [HumanMessage(content="Find the most appropriate relationships based on the user prompt provided.")]
+        )
+
+        valid = False
+        for attempt in range(MAX_RETRIES):
+            if answer.relationship in valid_relationships:
+                valid = True
+                break
+            else:
+                custom_logger.warning(f"The relationship is not valid. Trying again (attempt {attempt + 1}).")
+                answer = structured_llm.invoke([SystemMessage(content=system_message)])
+
+        if not valid:
+            custom_logger.error("Failed to get a valid relationship after maximum retries.")
+
+        if answer.relationship not in list(valid_relationships.keys()):
+            answer.relationship = None
+
+        triples.append((f"{subject}", f"{answer.relationship}", f"{object}"))
+
+    # Append the triples identified to the graph
+    graph = Graph()
+    BLDG = Namespace("urn:Building#")
+    BRICK = Namespace("https://brickschema.org/schema/Brick#")
+    RDF = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+
+    graph.bind("bldg", BLDG)
+    graph.bind("brick", BRICK)
+    graph.bind("rdf", RDF)
+
+    for triple in triples:
+        if triple[1] is not None:
+            graph.add((BLDG[triple[0]], BRICK[triple[1]], BLDG[triple[2]]))
+
+    for entity in entities_dict:
+        if not entities_dict[entity]["type"] is None:
+            graph.add((BLDG[entity], RDF.type, BRICK[entities_dict[entity]["type"]]))
+
+    return {"relationships": triples, "graph": graph}

--- a/brickllm/nodes/get_sensors.py
+++ b/brickllm/nodes/get_sensors.py
@@ -1,11 +1,18 @@
 import json
 from typing import Any, Dict
+import os
+import pkg_resources
 
 from langchain_core.messages import HumanMessage, SystemMessage
+from rdflib import Graph, Namespace, BNode, Literal, XSD
 
 from .. import SensorSchema, State
 from ..helpers import get_sensors_instructions
 from ..logger import custom_logger
+from ..utils import get_uom_dict
+
+ontology_path = pkg_resources.resource_filename(
+    __name__, os.path.join("..", "ontologies", "Brick.ttl"))
 
 
 def get_sensors(state: State, config: Dict[str, Any]) -> Dict[str, Any]:
@@ -21,9 +28,47 @@ def get_sensors(state: State, config: Dict[str, Any]) -> Dict[str, Any]:
     custom_logger.eurac("📡 Getting sensors information")
 
     user_prompt = state["user_prompt"]
-    sensor_structure = state["sensors_dict"]
-    sensor_structure_json = json.dumps(sensor_structure, indent=2)
+    graph = state["graph"]
 
+    g = Graph()
+    g.parse(ontology_path, format="turtle")
+
+    if graph is not None:
+        for triple in graph:
+            g.add(triple)
+
+    # Create a dictionary to store the sensor informations
+    sensor_dict = {}
+
+    # Identify the Point entities in the graph
+    query = """
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX brick: <https://brickschema.org/schema/Brick#>
+
+    SELECT ?point ?type
+    WHERE {
+        ?point rdf:type/rdfs:subClassOf* brick:Point .
+        ?point rdf:type ?type .
+    }
+    """
+
+    res_query = g.query(query)
+    point_type_list = []
+    for row in res_query:
+        point_type_list.append(str(row['type']).split("#")[1])
+        sensor_dict[str(row['point']).split("#")[1]] = {
+            "name": str(row['point']).split("#")[1],
+            "type": str(row['type']).split("#")[1],
+            "id": None,
+            "unit": None
+        }
+
+    point_type_list = list(set(point_type_list))
+    uom_dict = get_uom_dict(point_type_list)
+
+    sensor_structure_json = json.dumps(sensor_dict, indent=2)
+    uom_dict_json = json.dumps(uom_dict, indent=2)
     # Get the model name from the config
     llm = config.get("configurable", {}).get("llm_model")
 
@@ -31,13 +76,40 @@ def get_sensors(state: State, config: Dict[str, Any]) -> Dict[str, Any]:
     structured_llm = llm.with_structured_output(SensorSchema)
     # System message
     system_message = get_sensors_instructions.format(
-        prompt=user_prompt, sensor_structure=sensor_structure_json
+        prompt=user_prompt, sensor_structure=sensor_structure_json, unit_of_measures=uom_dict_json
     )
 
     # Generate question
     answer = structured_llm.invoke(
         [SystemMessage(content=system_message)]
-        + [HumanMessage(content="Complete the sensor structure.")]
     )
 
-    return {"uuid_list": answer.sensors}
+    # Encode the sensor information in the graph
+    sensors = answer.sensors
+
+    BLDG = Namespace("urn:Building#")
+    UNIT = Namespace("http://qudt.org/vocab/unit/")
+    BRICK = Namespace("https://brickschema.org/schema/Brick#")
+    REF = Namespace("https://brickschema.org/schema/Brick/ref#")
+    RDF = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+
+    graph.bind("bldg", BLDG)
+    graph.bind("brick", BRICK)
+    graph.bind("unit", UNIT)
+    graph.bind("ref", REF)
+    graph.bind("rdf", RDF)
+
+    for sensor in sensors:
+        timeseries_ref = BNode()
+        if sensor.unit is not None and sensor.unit != "None":
+            try:
+                graph.add((BLDG[sensor.name], BRICK.hasUnit, UNIT[sensor.unit]))
+            except:
+                custom_logger.warning(f"Unit {sensor.unit} not found in QUDT")
+
+        if sensor.id is not None:
+            graph.add((BLDG[sensor.name], REF.hasExternalReference, timeseries_ref))
+            graph.add((timeseries_ref, RDF.type, REF.TimeseriesReference))
+            graph.add((timeseries_ref, REF.hasTimeseriesId, Literal(sensor.id, datatype=XSD.string)))
+
+    return {"graph": graph, "sensor_dict": sensors}

--- a/brickllm/nodes/model_refactoring.py
+++ b/brickllm/nodes/model_refactoring.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from rdflib import Graph
+from io import StringIO
+
+from .. import State, TTLSchema
+from ..helpers import model_refactor_instructions
+from ..logger import custom_logger
+
+
+def model_refactoring(state: State, config: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Refactor the model based on the validation report.
+
+    Args:
+        state (State): The current state containing the validation report.
+        config (dict): Configuration dictionary containing the language model.
+
+    Returns:
+        dict: A dictionary containing the refactored model.
+    """
+    custom_logger.eurac("🔧 Refactoring the model")
+
+    validation_report = state["validation_report"]
+    graph = state["graph"]
+    user_prompt = state["user_prompt"]
+
+    # Get the model name from the config
+    llm = config.get("configurable", {}).get("llm_model")
+
+    # Enforce structured output
+    structured_llm = llm.with_structured_output(TTLSchema)
+
+    system_message = model_refactor_instructions.format(
+        validation_report=validation_report,
+        rdf_graph=graph.serialize(format="ttl"),
+        user_prompt=user_prompt
+    )
+
+    # Generate question
+    answer = structured_llm.invoke(
+        [SystemMessage(content=system_message)]
+    )
+
+    try:
+        graph = Graph().parse(StringIO(answer.ttl_output), format="ttl")
+    except Exception:
+        custom_logger.eurac("Refactoring failed.")
+
+    return {"graph": graph}

--- a/brickllm/nodes/validate_schema.py
+++ b/brickllm/nodes/validate_schema.py
@@ -16,19 +16,19 @@ def validate_schema(state) -> Dict[str, Any]:
     """
     custom_logger.eurac("✅ Validating TTL schema")
 
-    ttl_output = state.get("ttl_output", None)
-    max_iter = state.get("validation_max_iter", 2)
+    graph = state.get("graph", None)
+    max_iter = state.get("validation_max_iter", 3)
 
     max_iter -= 1
 
-    if ttl_output is None:
+    if graph is None:
         return {
             "is_valid": False,
             "validation_report": "Empty TTL output.",
             "validation_max_iter": max_iter,
         }
 
-    is_valid, report = validate_ttl(ttl_output)
+    is_valid, report = validate_ttl(graph)
 
     return {
         "is_valid": is_valid,

--- a/brickllm/ontologies/brick_hierarchy.json
+++ b/brickllm/ontologies/brick_hierarchy.json
@@ -1,489 +1,2045 @@
 {
-    "Location": {
-        "Space": {
-            "Room": {
-                "Service_Room": {
-                    "Electrical_Room": {},
-                    "Mechanical_Room": {}
-                },
-                "Media_Room": {},
-                "Laboratory": {},
-                "Food_Service_Room": {},
-                "Office": {
-                    "Enclosed_Office": {}
-                },
-                "Security_Service_Room": {},
-                "Telecom_Room": {
-                    "Distribution_Frame": {}
-                },
-                "Medical_Room": {},
-                "Storage_Room": {}
-            },
-            "Common_Space": {
-                "Lobby": {},
-                "Lounge": {}
-            },
-            "Vertical_Space": {}
-        },
-        "Floor": {},
-        "Outdoor_Area": {},
-        "Zone": {},
-        "Building": {}
-    },
-    "Equipment": {
-        "HVAC_Equipment": {
-            "Chiller": {},
-            "Terminal_Unit": {
-                "Chilled_Beam": {},
-                "Air_Diffuser": {},
-                "Radiator": {
-                    "Baseboard_Radiator": {}
-                },
-                "Radiant_Panel": {},
-                "Variable_Air_Volume_Box": {}
-            },
-            "Fan": {},
-            "Heat_Exchanger": {
-                "Coil": {
-                    "Cooling_Coil": {},
-                    "Heating_Coil": {}
-                }
-            },
-            "Pump": {
-                "Water_Pump": {}
-            },
-            "HVAC_Valve": {},
-            "Bypass_Valve": {},
-            "Isolation_Valve": {},
-            "Boiler": {
-                "Natural_Gas_Boiler": {}
-            },
-            "Heating_Valve": {
-                "Hot_Water_Valve": {}
-            },
-            "Damper": {},
-            "Filter": {},
-            "AHU": {},
-            "Air_Plenum": {
-                "Supply_Air_Plenum": {}
-            },
-            "CRAC": {}
-        },
-        "Security_Equipment": {
-            "Access_Control_Equipment": {},
-            "Intercom_Equipment": {},
-            "Video_Surveillance_Equipment": {}
-        },
-        "Shading_Equipment": {},
-        "Electrical_Equipment": {
-            "Energy_Storage": {}
-        },
-        "Meter": {
-            "Building_Meter": {},
-            "Water_Meter": {}
-        },
-        "Water_Heater": {},
-        "Lighting_Equipment": {
-            "Interface": {
-                "Switch": {}
-            },
-            "Lighting": {}
-        },
-        "Safety_Equipment": {
-            "Emergency_Wash_Station": {}
-        },
-        "Motor": {
-            "VFD": {}
-        },
-        "Fire_Safety_Equipment": {
-            "Manual_Fire_Alarm_Activation_Equipment": {}
-        },
-        "Valve": {
-            "Water_Valve": {}
-        },
-        "PV_Panel": {},
-        "Furniture": {},
-        "Camera": {}
-    },
     "Point": {
-        "Setpoint": {
-            "Time_Setpoint": {},
-            "Humidity_Setpoint": {},
-            "Pressure_Setpoint": {
-                "Static_Pressure_Setpoint": {
-                    "Discharge_Air_Static_Pressure_Setpoint": {}
+        "Parameter": {
+            "Delay_Parameter": {
+                "Alarm_Delay_Parameter": {}
+            },
+            "Alarm_Sensitivity_Parameter": {
+                "CO2_Alarm_Sensitivity_Parameter": {},
+                "Temperature_Alarm_Sensitivity_Parameter": {}
+            },
+            "Load_Parameter": {
+                "Max_Load_Setpoint": {},
+                "Min_Load_Setpoint": {}
+            },
+            "Tolerance_Parameter": {
+                "Humidity_Tolerance_Parameter": {},
+                "Temperature_Tolerance_Parameter": {}
+            },
+            "Humidity_Parameter": {
+                "High_Humidity_Alarm_Parameter": {},
+                "Humidity_Tolerance_Parameter": {},
+                "Low_Humidity_Alarm_Parameter": {}
+            },
+            "PID_Parameter": {
+                "Time_Parameter": {
+                    "Derivative_Time_Parameter": {},
+                    "Integral_Time_Parameter": {
+                        "Entering_Water_Temperature_Integral_Time_Parameter": {},
+                        "Leaving_Water_Temperature_Integral_Time_Parameter": {},
+                        "Exhaust_Air_Flow_Integral_Time_Parameter": {
+                            "Exhaust_Air_Stack_Flow_Integral_Time_Parameter": {}
+                        },
+                        "Static_Pressure_Integral_Time_Parameter": {
+                            "Supply_Air_Static_Pressure_Integral_Time_Parameter": {},
+                            "Discharge_Air_Static_Pressure_Integral_Time_Parameter": {}
+                        },
+                        "Air_Temperature_Integral_Time_Parameter": {
+                            "Cooling_Supply_Air_Temperature_Integral_Time_Parameter": {},
+                            "Heating_Supply_Air_Temperature_Integral_Time_Parameter": {},
+                            "Cooling_Discharge_Air_Temperature_Integral_Time_Parameter": {},
+                            "Heating_Discharge_Air_Temperature_Integral_Time_Parameter": {}
+                        },
+                        "Differential_Pressure_Integral_Time_Parameter": {
+                            "Chilled_Water_Differential_Pressure_Integral_Time_Parameter": {},
+                            "Entering_Water_Differential_Pressure_Integral_Time_Parameter": {},
+                            "Hot_Water_Differential_Pressure_Integral_Time_Parameter": {},
+                            "Leaving_Water_Differential_Pressure_Integral_Time_Parameter": {}
+                        }
+                    }
+                },
+                "Gain_Parameter": {
+                    "Derivative_Gain_Parameter": {},
+                    "Integral_Gain_Parameter": {
+                        "Supply_Air_Integral_Gain_Parameter": {},
+                        "Discharge_Air_Integral_Gain_Parameter": {}
+                    },
+                    "Proportional_Gain_Parameter": {
+                        "Supply_Air_Proportional_Gain_Parameter": {},
+                        "Discharge_Air_Proportional_Gain_Parameter": {}
+                    }
+                },
+                "Step_Parameter": {
+                    "Differential_Pressure_Step_Parameter": {
+                        "Chilled_Water_Differential_Pressure_Step_Parameter": {}
+                    },
+                    "Static_Pressure_Step_Parameter": {
+                        "Air_Static_Pressure_Step_Parameter": {
+                            "Supply_Air_Static_Pressure_Step_Parameter": {},
+                            "Discharge_Air_Static_Pressure_Step_Parameter": {}
+                        }
+                    },
+                    "Temperature_Step_Parameter": {
+                        "Air_Temperature_Step_Parameter": {
+                            "Supply_Air_Temperature_Step_Parameter": {},
+                            "Discharge_Air_Temperature_Step_Parameter": {}
+                        }
+                    }
+                },
+                "Proportional_Band_Parameter": {
+                    "Entering_Water_Temperature_Proportional_Band_Parameter": {},
+                    "Leaving_Water_Temperature_Proportional_Band_Parameter": {},
+                    "Exhaust_Air_Flow_Proportional_Band_Parameter": {
+                        "Exhaust_Air_Stack_Flow_Proportional_Band_Parameter": {}
+                    },
+                    "Supply_Air_Temperature_Proportional_Band_Parameter": {
+                        "Cooling_Supply_Air_Temperature_Proportional_Band_Parameter": {},
+                        "Heating_Supply_Air_Temperature_Proportional_Band_Parameter": {}
+                    },
+                    "Discharge_Air_Temperature_Proportional_Band_Parameter": {
+                        "Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter": {},
+                        "Heating_Discharge_Air_Temperature_Proportional_Band_Parameter": {}
+                    },
+                    "Static_Pressure_Proportional_Band_Parameter": {
+                        "Exhaust_Air_Static_Pressure_Proportional_Band_Parameter": {},
+                        "Supply_Air_Static_Pressure_Proportional_Band_Parameter": {},
+                        "Discharge_Air_Static_Pressure_Proportional_Band_Parameter": {}
+                    },
+                    "Differential_Pressure_Proportional_Band": {
+                        "Chilled_Water_Differential_Pressure_Proportional_Band_Parameter": {},
+                        "Entering_Water_Differential_Pressure_Proportional_Band_Parameter": {},
+                        "Hot_Water_Differential_Pressure_Proportional_Band_Parameter": {},
+                        "Leaving_Water_Differential_Pressure_Proportional_Band_Parameter": {}
+                    }
                 }
+            },
+            "Limit": {
+                "Close_Limit": {},
+                "Current_Limit": {},
+                "Ventilation_Air_Flow_Ratio_Limit": {},
+                "Air_Flow_Setpoint_Limit": {
+                    "Max_Air_Flow_Setpoint_Limit": {
+                        "Max_Outside_Air_Flow_Setpoint_Limit": {},
+                        "Max_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                            "Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {},
+                            "Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Max_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                            "Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {},
+                            "Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Max_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                            "Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {},
+                            "Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Max_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                            "Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {},
+                            "Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {}
+                        }
+                    },
+                    "Min_Air_Flow_Setpoint_Limit": {
+                        "Min_Outside_Air_Flow_Setpoint_Limit": {},
+                        "Min_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                            "Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {},
+                            "Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Min_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                            "Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {},
+                            "Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Min_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                            "Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {},
+                            "Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Min_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                            "Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {},
+                            "Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {}
+                        }
+                    }
+                },
+                "Air_Temperature_Setpoint_Limit": {
+                    "Supply_Air_Temperature_Setpoint_Limit": {
+                        "Max_Supply_Air_Temperature_Setpoint_Limit": {},
+                        "Min_Supply_Air_Temperature_Setpoint_Limit": {}
+                    },
+                    "Discharge_Air_Temperature_Setpoint_Limit": {
+                        "Max_Discharge_Air_Temperature_Setpoint_Limit": {},
+                        "Min_Discharge_Air_Temperature_Setpoint_Limit": {}
+                    }
+                },
+                "Fresh_Air_Setpoint_Limit": {
+                    "Max_Fresh_Air_Setpoint_Limit": {},
+                    "Min_Fresh_Air_Setpoint_Limit": {}
+                },
+                "Position_Limit": {
+                    "Max_Position_Setpoint_Limit": {},
+                    "Min_Position_Setpoint_Limit": {}
+                },
+                "Speed_Setpoint_Limit": {
+                    "Max_Speed_Setpoint_Limit": {},
+                    "Min_Speed_Setpoint_Limit": {}
+                },
+                "Static_Pressure_Setpoint_Limit": {
+                    "High_Static_Pressure_Cutout_Setpoint_Limit": {},
+                    "Max_Static_Pressure_Setpoint_Limit": {
+                        "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {},
+                        "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {}
+                    },
+                    "Min_Static_Pressure_Setpoint_Limit": {
+                        "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {},
+                        "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {}
+                    }
+                },
+                "Differential_Pressure_Setpoint_Limit": {
+                    "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {},
+                    "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {},
+                    "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {},
+                    "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {}
+                },
+                "Max_Limit": {
+                    "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {},
+                    "Max_Fresh_Air_Setpoint_Limit": {},
+                    "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {},
+                    "Max_Position_Setpoint_Limit": {},
+                    "Max_Speed_Setpoint_Limit": {},
+                    "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {},
+                    "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {},
+                    "Max_Static_Pressure_Setpoint_Limit": {
+                        "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {},
+                        "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {}
+                    },
+                    "Max_Temperature_Setpoint_Limit": {
+                        "Max_Supply_Air_Temperature_Setpoint_Limit": {},
+                        "Max_Discharge_Air_Temperature_Setpoint_Limit": {}
+                    },
+                    "Max_Air_Flow_Setpoint_Limit": {
+                        "Max_Outside_Air_Flow_Setpoint_Limit": {},
+                        "Max_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                            "Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {},
+                            "Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Max_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                            "Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {},
+                            "Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Max_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                            "Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {},
+                            "Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Max_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                            "Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {},
+                            "Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {}
+                        }
+                    }
+                },
+                "Min_Limit": {
+                    "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {},
+                    "Min_Fresh_Air_Setpoint_Limit": {},
+                    "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {},
+                    "Min_Position_Setpoint_Limit": {},
+                    "Min_Speed_Setpoint_Limit": {},
+                    "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {},
+                    "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {},
+                    "Min_Static_Pressure_Setpoint_Limit": {
+                        "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {},
+                        "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {}
+                    },
+                    "Min_Temperature_Setpoint_Limit": {
+                        "Min_Supply_Air_Temperature_Setpoint_Limit": {},
+                        "Min_Discharge_Air_Temperature_Setpoint_Limit": {}
+                    },
+                    "Min_Air_Flow_Setpoint_Limit": {
+                        "Min_Outside_Air_Flow_Setpoint_Limit": {},
+                        "Min_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                            "Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {},
+                            "Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Min_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                            "Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {},
+                            "Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Min_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                            "Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {},
+                            "Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {}
+                        },
+                        "Min_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                            "Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {},
+                            "Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {}
+                        }
+                    }
+                }
+            },
+            "Temperature_Parameter": {
+                "Entering_Water_Temperature_Integral_Time_Parameter": {},
+                "Entering_Water_Temperature_Proportional_Band_Parameter": {},
+                "High_Temperature_Alarm_Parameter": {},
+                "Leaving_Water_Temperature_Integral_Time_Parameter": {},
+                "Leaving_Water_Temperature_Proportional_Band_Parameter": {},
+                "Low_Freeze_Protect_Temperature_Parameter": {},
+                "Low_Temperature_Alarm_Parameter": {},
+                "Temperature_Tolerance_Parameter": {},
+                "Lockout_Temperature_Differential_Parameter": {
+                    "Outside_Air_Lockout_Temperature_Differential_Parameter": {
+                        "High_Outside_Air_Lockout_Temperature_Differential_Parameter": {},
+                        "Low_Outside_Air_Lockout_Temperature_Differential_Parameter": {}
+                    }
+                },
+                "Temperature_Step_Parameter": {
+                    "Air_Temperature_Step_Parameter": {
+                        "Supply_Air_Temperature_Step_Parameter": {},
+                        "Discharge_Air_Temperature_Step_Parameter": {}
+                    }
+                },
+                "Air_Temperature_Setpoint_Limit": {
+                    "Supply_Air_Temperature_Setpoint_Limit": {
+                        "Max_Supply_Air_Temperature_Setpoint_Limit": {},
+                        "Min_Supply_Air_Temperature_Setpoint_Limit": {}
+                    },
+                    "Discharge_Air_Temperature_Setpoint_Limit": {
+                        "Max_Discharge_Air_Temperature_Setpoint_Limit": {},
+                        "Min_Discharge_Air_Temperature_Setpoint_Limit": {}
+                    }
+                },
+                "Max_Temperature_Setpoint_Limit": {
+                    "Max_Supply_Air_Temperature_Setpoint_Limit": {},
+                    "Max_Discharge_Air_Temperature_Setpoint_Limit": {}
+                },
+                "Min_Temperature_Setpoint_Limit": {
+                    "Min_Supply_Air_Temperature_Setpoint_Limit": {},
+                    "Min_Discharge_Air_Temperature_Setpoint_Limit": {}
+                },
+                "Supply_Air_Temperature_Proportional_Band_Parameter": {
+                    "Cooling_Supply_Air_Temperature_Proportional_Band_Parameter": {},
+                    "Heating_Supply_Air_Temperature_Proportional_Band_Parameter": {}
+                },
+                "Discharge_Air_Temperature_Proportional_Band_Parameter": {
+                    "Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter": {},
+                    "Heating_Discharge_Air_Temperature_Proportional_Band_Parameter": {}
+                },
+                "Air_Temperature_Integral_Time_Parameter": {
+                    "Cooling_Supply_Air_Temperature_Integral_Time_Parameter": {},
+                    "Heating_Supply_Air_Temperature_Integral_Time_Parameter": {},
+                    "Cooling_Discharge_Air_Temperature_Integral_Time_Parameter": {},
+                    "Heating_Discharge_Air_Temperature_Integral_Time_Parameter": {}
+                }
+            }
+        },
+        "Setpoint": {
+            "Current_Ratio_Setpoint": {},
+            "Damper_Position_Setpoint": {},
+            "Dewpoint_Setpoint": {},
+            "Enthalpy_Setpoint": {},
+            "Frequency_Setpoint": {},
+            "Illuminance_Setpoint": {},
+            "Luminance_Setpoint": {},
+            "Voltage_Ratio_Setpoint": {},
+            "CO2_Setpoint": {
+                "Return_Air_CO2_Setpoint": {}
+            },
+            "Load_Setpoint": {
+                "Load_Shed_Setpoint": {
+                    "Entering_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {},
+                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {},
+                    "Load_Shed_Differential_Pressure_Setpoint": {
+                        "Chilled_Water_Differential_Pressure_Load_Shed_Setpoint": {}
+                    }
+                }
+            },
+            "Speed_Setpoint": {
+                "Rated_Speed_Setpoint": {}
             },
             "Flow_Setpoint": {
-                "Water_Flow_Setpoint": {
-                    "Chilled_Water_Flow_Setpoint": {},
-                    "Entering_Water_Flow_Setpoint": {},
-                    "Hot_Water_Flow_Setpoint": {},
-                    "Discharge_Water_Flow_Setpoint": {}
-                },
                 "Air_Flow_Setpoint": {
-                    "Air_Flow_Deadband_Setpoint": {},
-                    "Supply_Air_Flow_Setpoint": {
-                        "Cooling_Supply_Air_Flow_Setpoint": {},
-                        "Heating_Supply_Air_Flow_Setpoint": {}
+                    "Outside_Air_Flow_Setpoint": {},
+                    "Air_Flow_Deadband_Setpoint": {
+                        "Exhaust_Air_Stack_Flow_Deadband_Setpoint": {}
                     },
-                    "Air_Flow_Demand_Setpoint": {},
-                    "Exhaust_Air_Flow_Setpoint": {},
+                    "Exhaust_Air_Flow_Setpoint": {
+                        "Exhaust_Air_Stack_Flow_Setpoint": {
+                            "Exhaust_Air_Stack_Flow_Deadband_Setpoint": {}
+                        }
+                    },
+                    "Air_Flow_Demand_Setpoint": {
+                        "Supply_Air_Flow_Demand_Setpoint": {},
+                        "Discharge_Air_Flow_Demand_Setpoint": {}
+                    },
+                    "Supply_Air_Flow_Setpoint": {
+                        "Supply_Air_Flow_Demand_Setpoint": {},
+                        "Cooling_Supply_Air_Flow_Setpoint": {
+                            "Occupied_Cooling_Supply_Air_Flow_Setpoint": {},
+                            "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {}
+                        },
+                        "Heating_Supply_Air_Flow_Setpoint": {
+                            "Occupied_Heating_Supply_Air_Flow_Setpoint": {},
+                            "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {}
+                        },
+                        "Occupied_Supply_Air_Flow_Setpoint": {
+                            "Occupied_Cooling_Supply_Air_Flow_Setpoint": {},
+                            "Occupied_Heating_Supply_Air_Flow_Setpoint": {}
+                        },
+                        "Unoccupied_Supply_Air_Flow_Setpoint": {
+                            "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {},
+                            "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {}
+                        }
+                    },
                     "Discharge_Air_Flow_Setpoint": {
-                        "Cooling_Discharge_Air_Flow_Setpoint": {},
-                        "Heating_Discharge_Air_Flow_Setpoint": {}
+                        "Discharge_Air_Flow_Demand_Setpoint": {},
+                        "Cooling_Discharge_Air_Flow_Setpoint": {
+                            "Occupied_Cooling_Discharge_Air_Flow_Setpoint": {},
+                            "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint": {}
+                        },
+                        "Heating_Discharge_Air_Flow_Setpoint": {
+                            "Occupied_Heating_Discharge_Air_Flow_Setpoint": {},
+                            "Unoccupied_Heating_Discharge_Air_Flow_Setpoint": {}
+                        },
+                        "Occupied_Discharge_Air_Flow_Setpoint": {
+                            "Occupied_Cooling_Discharge_Air_Flow_Setpoint": {},
+                            "Occupied_Heating_Discharge_Air_Flow_Setpoint": {}
+                        },
+                        "Unoccupied_Discharge_Air_Flow_Setpoint": {
+                            "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint": {},
+                            "Unoccupied_Heating_Discharge_Air_Flow_Setpoint": {}
+                        }
+                    }
+                },
+                "Water_Flow_Setpoint": {
+                    "Bypass_Water_Flow_Setpoint": {},
+                    "Condenser_Water_Flow_Setpoint": {},
+                    "Entering_Water_Flow_Setpoint": {
+                        "Entering_Chilled_Water_Flow_Setpoint": {},
+                        "Entering_Hot_Water_Flow_Setpoint": {}
+                    },
+                    "Leaving_Water_Flow_Setpoint": {
+                        "Leaving_Chilled_Water_Flow_Setpoint": {},
+                        "Leaving_Hot_Water_Flow_Setpoint": {}
+                    },
+                    "Supply_Water_Flow_Setpoint": {
+                        "Chilled_Water_Supply_Flow_Setpoint": {}
+                    },
+                    "Discharge_Water_Flow_Setpoint": {
+                        "Chilled_Water_Discharge_Flow_Setpoint": {},
+                        "Hot_Water_Discharge_Flow_Setpoint": {}
+                    },
+                    "Hot_Water_Flow_Setpoint": {
+                        "Entering_Hot_Water_Flow_Setpoint": {},
+                        "Leaving_Hot_Water_Flow_Setpoint": {},
+                        "Hot_Water_Discharge_Flow_Setpoint": {}
+                    },
+                    "Chilled_Water_Flow_Setpoint": {
+                        "Entering_Chilled_Water_Flow_Setpoint": {},
+                        "Leaving_Chilled_Water_Flow_Setpoint": {},
+                        "Chilled_Water_Discharge_Flow_Setpoint": {},
+                        "Chilled_Water_Supply_Flow_Setpoint": {}
+                    }
+                }
+            },
+            "Pressure_Setpoint": {
+                "Velocity_Pressure_Setpoint": {},
+                "Static_Pressure_Setpoint": {
+                    "Building_Air_Static_Pressure_Setpoint": {},
+                    "Chilled_Water_Static_Pressure_Setpoint": {},
+                    "Exhaust_Air_Static_Pressure_Setpoint": {},
+                    "Hot_Water_Static_Pressure_Setpoint": {},
+                    "Underfloor_Air_Plenum_Static_Pressure_Setpoint": {},
+                    "Supply_Air_Static_Pressure_Setpoint": {
+                        "Supply_Air_Static_Pressure_Deadband_Setpoint": {}
+                    },
+                    "Discharge_Air_Static_Pressure_Setpoint": {
+                        "Discharge_Air_Static_Pressure_Deadband_Setpoint": {}
+                    },
+                    "Static_Pressure_Deadband_Setpoint": {
+                        "Supply_Air_Static_Pressure_Deadband_Setpoint": {},
+                        "Discharge_Air_Static_Pressure_Deadband_Setpoint": {}
+                    }
+                }
+            },
+            "Time_Setpoint": {
+                "Acceleration_Time_Setpoint": {},
+                "Deceleration_Time_Setpoint": {}
+            },
+            "Deadband_Setpoint": {
+                "Humidity_Deadband_Setpoint": {},
+                "Air_Flow_Deadband_Setpoint": {
+                    "Exhaust_Air_Stack_Flow_Deadband_Setpoint": {}
+                },
+                "Static_Pressure_Deadband_Setpoint": {
+                    "Supply_Air_Static_Pressure_Deadband_Setpoint": {},
+                    "Discharge_Air_Static_Pressure_Deadband_Setpoint": {}
+                },
+                "Temperature_Deadband_Setpoint": {
+                    "Entering_Water_Temperature_Deadband_Setpoint": {},
+                    "Leaving_Water_Temperature_Deadband_Setpoint": {},
+                    "Occupied_Cooling_Temperature_Deadband_Setpoint": {},
+                    "Occupied_Heating_Temperature_Deadband_Setpoint": {},
+                    "Unoccupied_Cooling_Temperature_Deadband_Setpoint": {},
+                    "Unoccupied_Heating_Temperature_Deadband_Setpoint": {},
+                    "Supply_Air_Temperature_Deadband_Setpoint": {
+                        "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {},
+                        "Heating_Supply_Air_Temperature_Deadband_Setpoint": {}
+                    },
+                    "Discharge_Air_Temperature_Deadband_Setpoint": {
+                        "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {},
+                        "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {}
+                    }
+                }
+            },
+            "Demand_Setpoint": {
+                "Cooling_Demand_Setpoint": {},
+                "Heating_Demand_Setpoint": {},
+                "Preheat_Demand_Setpoint": {},
+                "Air_Flow_Demand_Setpoint": {
+                    "Supply_Air_Flow_Demand_Setpoint": {},
+                    "Discharge_Air_Flow_Demand_Setpoint": {}
+                }
+            },
+            "Reset_Setpoint": {
+                "Supply_Air_Flow_Reset_Setpoint": {
+                    "Supply_Air_Flow_High_Reset_Setpoint": {},
+                    "Supply_Air_Flow_Low_Reset_Setpoint": {}
+                },
+                "Discharge_Air_Flow_Reset_Setpoint": {
+                    "Discharge_Air_Flow_High_Reset_Setpoint": {},
+                    "Discharge_Air_Flow_Low_Reset_Setpoint": {}
+                },
+                "Temperature_High_Reset_Setpoint": {
+                    "Outside_Air_Temperature_High_Reset_Setpoint": {},
+                    "Return_Air_Temperature_High_Reset_Setpoint": {},
+                    "Supply_Air_Temperature_High_Reset_Setpoint": {},
+                    "Entering_Hot_Water_Temperature_High_Reset_Setpoint": {
+                        "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {}
+                    },
+                    "Leaving_Hot_Water_Temperature_High_Reset_Setpoint": {
+                        "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {}
+                    }
+                },
+                "Temperature_Low_Reset_Setpoint": {
+                    "Outside_Air_Temperature_Low_Reset_Setpoint": {},
+                    "Return_Air_Temperature_Low_Reset_Setpoint": {},
+                    "Supply_Air_Temperature_Low_Reset_Setpoint": {},
+                    "Entering_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                        "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {}
+                    },
+                    "Leaving_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                        "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {}
                     }
                 }
             },
             "Differential_Setpoint": {
-                "Differential_Pressure_Deadband_Setpoint": {},
-                "Differential_Pressure_Setpoint": {
-                    "Water_Differential_Pressure_Setpoint": {
-                        "Chilled_Water_Differential_Pressure_Setpoint": {},
-                        "Hot_Water_Differential_Pressure_Setpoint": {}
-                    },
-                    "Air_Differential_Pressure_Setpoint": {}
+                "Differential_Speed_Setpoint": {},
+                "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {},
+                "Differential_Temperature_Setpoint": {
+                    "Differential_Air_Temperature_Setpoint": {},
+                    "Water_Differential_Temperature_Setpoint": {}
                 },
-                "Differential_Temperature_Setpoint": {},
                 "Temperature_Differential_Reset_Setpoint": {
-                    "Discharge_Air_Temperature_Reset_Differential_Setpoint": {}
+                    "Supply_Air_Temperature_Reset_Differential_Setpoint": {},
+                    "Discharge_Air_Temperature_Reset_Differential_Setpoint": {
+                        "Discharge_Air_Temperature_High_Reset_Setpoint": {},
+                        "Discharge_Air_Temperature_Low_Reset_Setpoint": {}
+                    }
+                },
+                "Differential_Pressure_Setpoint": {
+                    "Load_Shed_Differential_Pressure_Setpoint": {
+                        "Chilled_Water_Differential_Pressure_Load_Shed_Setpoint": {}
+                    },
+                    "Water_Differential_Pressure_Setpoint": {
+                        "Chilled_Water_Differential_Pressure_Setpoint": {
+                            "Chilled_Water_Differential_Pressure_Load_Shed_Setpoint": {}
+                        },
+                        "Hot_Water_Differential_Pressure_Setpoint": {
+                            "Medium_Temperature_Hot_Water_Differential_Pressure_Setpoint": {}
+                        }
+                    },
+                    "Air_Differential_Pressure_Setpoint": {
+                        "Discharge_Air_Differential_Pressure_Setpoint": {},
+                        "Exhaust_Air_Differential_Pressure_Setpoint": {},
+                        "Return_Air_Differential_Pressure_Setpoint": {},
+                        "Supply_Air_Differential_Pressure_Setpoint": {}
+                    }
+                },
+                "Differential_Pressure_Deadband_Setpoint": {
+                    "Chilled_Water_Differential_Pressure_Deadband_Setpoint": {},
+                    "Entering_Water_Differential_Pressure_Deadband_Setpoint": {},
+                    "Hot_Water_Differential_Pressure_Deadband_Setpoint": {},
+                    "Leaving_Water_Differential_Pressure_Deadband_Setpoint": {}
                 }
             },
-            "Demand_Setpoint": {},
             "Temperature_Setpoint": {
-                "Cooling_Temperature_Setpoint": {
-                    "Discharge_Air_Temperature_Cooling_Setpoint": {}
-                },
+                "Schedule_Temperature_Setpoint": {},
                 "Radiant_Panel_Temperature_Setpoint": {
-                    "Embedded_Temperature_Setpoint": {}
+                    "Inside_Face_Surface_Temperature_Setpoint": {},
+                    "Outside_Face_Surface_Temperature_Setpoint": {},
+                    "Embedded_Temperature_Setpoint": {
+                        "Core_Temperature_Setpoint": {}
+                    }
                 },
-                "Air_Temperature_Setpoint": {
-                    "Outside_Air_Temperature_Setpoint": {},
-                    "Effective_Air_Temperature_Setpoint": {},
-                    "Occupied_Air_Temperature_Setpoint": {},
-                    "Return_Air_Temperature_Setpoint": {},
-                    "Room_Air_Temperature_Setpoint": {},
-                    "Supply_Air_Temperature_Setpoint": {},
-                    "Unoccupied_Air_Temperature_Setpoint": {},
-                    "Discharge_Air_Temperature_Setpoint": {
-                        "Discharge_Air_Temperature_Deadband_Setpoint": {}
+                "Temperature_Deadband_Setpoint": {
+                    "Entering_Water_Temperature_Deadband_Setpoint": {},
+                    "Leaving_Water_Temperature_Deadband_Setpoint": {},
+                    "Occupied_Cooling_Temperature_Deadband_Setpoint": {},
+                    "Occupied_Heating_Temperature_Deadband_Setpoint": {},
+                    "Unoccupied_Cooling_Temperature_Deadband_Setpoint": {},
+                    "Unoccupied_Heating_Temperature_Deadband_Setpoint": {},
+                    "Supply_Air_Temperature_Deadband_Setpoint": {
+                        "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {},
+                        "Heating_Supply_Air_Temperature_Deadband_Setpoint": {}
+                    },
+                    "Discharge_Air_Temperature_Deadband_Setpoint": {
+                        "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {},
+                        "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {}
                     }
                 },
                 "Water_Temperature_Setpoint": {
-                    "Chilled_Water_Temperature_Setpoint": {},
-                    "Leaving_Water_Temperature_Setpoint": {},
+                    "Max_Water_Temperature_Setpoint": {},
+                    "Min_Water_Temperature_Setpoint": {},
+                    "Domestic_Hot_Water_Temperature_Setpoint": {
+                        "Entering_Domestic_Hot_Water_Temperature_Setpoint": {},
+                        "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {}
+                    },
                     "Hot_Water_Temperature_Setpoint": {
-                        "Domestic_Hot_Water_Temperature_Setpoint": {}
+                        "Entering_Hot_Water_Temperature_Setpoint": {},
+                        "Leaving_Hot_Water_Temperature_Setpoint": {},
+                        "Domestic_Hot_Water_Temperature_Setpoint": {
+                            "Entering_Domestic_Hot_Water_Temperature_Setpoint": {},
+                            "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {}
+                        }
                     },
-                    "Entering_Water_Temperature_Setpoint": {},
-                    "Return_Water_Temperature_Setpoint": {}
-                },
-                "Heating_Temperature_Setpoint": {}
-            },
-            "Reset_Setpoint": {
-                "Temperature_High_Reset_Setpoint": {
-                    "Entering_Hot_Water_Temperature_High_Reset_Setpoint": {},
-                    "Leaving_Hot_Water_Temperature_High_Reset_Setpoint": {}
-                },
-                "Temperature_Low_Reset_Setpoint": {
-                    "Entering_Hot_Water_Temperature_Low_Reset_Setpoint": {},
-                    "Leaving_Hot_Water_Temperature_Low_Reset_Setpoint": {}
-                },
-                "Supply_Air_Flow_Reset_Setpoint": {},
-                "Discharge_Air_Flow_Reset_Setpoint": {}
-            },
-            "Load_Setpoint": {
-                "Load_Shed_Setpoint": {}
-            },
-            "Deadband_Setpoint": {
-                "Static_Pressure_Deadband_Setpoint": {}
-            },
-            "Speed_Setpoint": {},
-            "CO2_Setpoint": {}
-        },
-        "Sensor": {
-            "Power_Sensor": {
-                "Electric_Power_Sensor": {},
-                "Thermal_Power_Sensor": {}
-            },
-            "Air_Quality_Sensor": {
-                "CO2_Sensor": {},
-                "CO_Sensor": {},
-                "Particulate_Matter_Sensor": {
-                    "PM10_Sensor": {},
-                    "PM1_Sensor": {},
-                    "TVOC_Sensor": {}
-                },
-                "Radioactivity_Concentration_Sensor": {}
-            },
-            "Demand_Sensor": {
-                "Cooling_Demand_Sensor": {},
-                "Heating_Demand_Sensor": {}
-            },
-            "Pressure_Sensor": {
-                "Static_Pressure_Sensor": {
-                    "Exhaust_Air_Static_Pressure_Sensor": {}
-                },
-                "Differential_Pressure_Sensor": {
-                    "Air_Differential_Pressure_Sensor": {},
-                    "Hot_Water_Differential_Pressure_Sensor": {}
-                },
-                "Velocity_Pressure_Sensor": {}
-            },
-            "Flow_Sensor": {
-                "Air_Flow_Sensor": {
-                    "Supply_Air_Flow_Sensor": {},
-                    "Exhaust_Air_Flow_Sensor": {},
-                    "Discharge_Air_Flow_Sensor": {}
-                },
-                "Water_Flow_Sensor": {
-                    "Chilled_Water_Flow_Sensor": {},
-                    "Entering_Water_Flow_Sensor": {},
-                    "Condenser_Water_Flow_Sensor": {},
-                    "Hot_Water_Flow_Sensor": {},
-                    "Discharge_Water_Flow_Sensor": {}
-                }
-            },
-            "Temperature_Sensor": {
-                "Air_Temperature_Sensor": {
-                    "Zone_Air_Temperature_Sensor": {},
-                    "Outside_Air_Temperature_Sensor": {
-                        "Outside_Air_Temperature_Enable_Differential_Sensor": {}
+                    "Entering_Water_Temperature_Setpoint": {
+                        "Entering_Chilled_Water_Temperature_Setpoint": {},
+                        "Entering_Domestic_Hot_Water_Temperature_Setpoint": {},
+                        "Entering_Hot_Water_Temperature_Setpoint": {},
+                        "Entering_Water_Temperature_Deadband_Setpoint": {}
                     },
-                    "Air_Wet_Bulb_Temperature_Sensor": {},
-                    "Supply_Air_Temperature_Sensor": {},
-                    "Discharge_Air_Temperature_Sensor": {}
-                },
-                "Water_Temperature_Sensor": {
-                    "Chilled_Water_Temperature_Sensor": {},
-                    "Condenser_Water_Temperature_Sensor": {},
-                    "Domestic_Hot_Water_Temperature_Sensor": {},
-                    "Entering_Hot_Water_Temperature_Sensor": {},
-                    "Leaving_Water_Temperature_Sensor": {},
-                    "Leaving_Hot_Water_Temperature_Sensor": {},
-                    "Water_Differential_Temperature_Sensor": {},
-                    "Discharge_Water_Temperature_Sensor": {
-                        "Discharge_Hot_Water_Temperature_Setpoint": {},
-                        "Hot_Water_Discharge_Temperature_Sensor": {}
+                    "Return_Water_Temperature_Setpoint": {
+                        "Return_Chilled_Water_Temperature_Setpoint": {},
+                        "Return_Condenser_Water_Temperature_Setpoint": {},
+                        "Return_Hot_Water_Temperature_Setpoint": {}
                     },
-                    "Supply_Water_Temperature_Sensor": {
-                        "Hot_Water_Supply_Temperature_Sensor": {},
-                        "Supply_Hot_Water_Temperature_Setpoint": {}
+                    "Chilled_Water_Temperature_Setpoint": {
+                        "Entering_Chilled_Water_Temperature_Setpoint": {},
+                        "Leaving_Chilled_Water_Temperature_Setpoint": {},
+                        "Discharge_Chilled_Water_Temperature_Setpoint": {},
+                        "Return_Chilled_Water_Temperature_Setpoint": {},
+                        "Supply_Chilled_Water_Temperature_Setpoint": {}
                     },
-                    "Return_Water_Temperature_Sensor": {
-                        "Hot_Water_Return_Temperature_Sensor": {}
+                    "Leaving_Water_Temperature_Setpoint": {
+                        "Entering_Condenser_Water_Temperature_Setpoint": {},
+                        "Leaving_Chilled_Water_Temperature_Setpoint": {},
+                        "Leaving_Condenser_Water_Temperature_Setpoint": {},
+                        "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {},
+                        "Leaving_Hot_Water_Temperature_Setpoint": {},
+                        "Leaving_Water_Temperature_Deadband_Setpoint": {}
                     }
                 },
-                "Radiant_Panel_Temperature_Sensor": {
-                    "Embedded_Temperature_Sensor": {}
+                "Cooling_Temperature_Setpoint": {
+                    "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {},
+                    "Effective_Air_Temperature_Cooling_Setpoint": {},
+                    "Occupied_Air_Temperature_Cooling_Setpoint": {},
+                    "Occupied_Cooling_Temperature_Deadband_Setpoint": {},
+                    "Occupied_Cooling_Temperature_Setpoint": {},
+                    "Supply_Air_Temperature_Cooling_Setpoint": {},
+                    "Unoccupied_Air_Temperature_Cooling_Setpoint": {},
+                    "Unoccupied_Cooling_Temperature_Deadband_Setpoint": {},
+                    "Unoccupied_Cooling_Temperature_Setpoint": {},
+                    "Zone_Air_Cooling_Temperature_Setpoint": {},
+                    "Discharge_Air_Temperature_Cooling_Setpoint": {
+                        "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {}
+                    }
+                },
+                "Heating_Temperature_Setpoint": {
+                    "Effective_Air_Temperature_Heating_Setpoint": {},
+                    "Heating_Supply_Air_Temperature_Deadband_Setpoint": {},
+                    "Occupied_Air_Temperature_Heating_Setpoint": {},
+                    "Occupied_Heating_Temperature_Deadband_Setpoint": {},
+                    "Occupied_Heating_Temperature_Setpoint": {},
+                    "Open_Heating_Valve_Outside_Air_Temperature_Setpoint": {},
+                    "Supply_Air_Temperature_Heating_Setpoint": {},
+                    "Unoccupied_Air_Temperature_Heating_Setpoint": {},
+                    "Unoccupied_Heating_Temperature_Deadband_Setpoint": {},
+                    "Unoccupied_Heating_Temperature_Setpoint": {},
+                    "Zone_Air_Heating_Temperature_Setpoint": {},
+                    "Discharge_Air_Temperature_Heating_Setpoint": {
+                        "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {}
+                    }
+                },
+                "Air_Temperature_Setpoint": {
+                    "Max_Air_Temperature_Setpoint": {},
+                    "Min_Air_Temperature_Setpoint": {},
+                    "Mixed_Air_Temperature_Setpoint": {},
+                    "Supply_Air_Temperature_Deadband_Setpoint": {
+                        "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {},
+                        "Heating_Supply_Air_Temperature_Deadband_Setpoint": {}
+                    },
+                    "Return_Air_Temperature_Setpoint": {
+                        "Effective_Return_Air_Temperature_Setpoint": {},
+                        "Occupied_Return_Air_Temperature_Setpoint": {},
+                        "Unoccupied_Return_Air_Temperature_Setpoint": {}
+                    },
+                    "Room_Air_Temperature_Setpoint": {
+                        "Effective_Room_Air_Temperature_Setpoint": {},
+                        "Occupied_Room_Air_Temperature_Setpoint": {},
+                        "Unoccupied_Room_Air_Temperature_Setpoint": {}
+                    },
+                    "Outside_Air_Temperature_Setpoint": {
+                        "Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {},
+                        "Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {},
+                        "Low_Outside_Air_Temperature_Enable_Setpoint": {},
+                        "Open_Heating_Valve_Outside_Air_Temperature_Setpoint": {},
+                        "Outside_Air_Lockout_Temperature_Setpoint": {}
+                    },
+                    "Supply_Air_Temperature_Setpoint": {
+                        "Effective_Supply_Air_Temperature_Setpoint": {},
+                        "Occupied_Supply_Air_Temperature_Setpoint": {},
+                        "Supply_Air_Temperature_Cooling_Setpoint": {},
+                        "Supply_Air_Temperature_Heating_Setpoint": {},
+                        "Unoccupied_Supply_Air_Temperature_Setpoint": {}
+                    },
+                    "Zone_Air_Temperature_Setpoint": {
+                        "Effective_Zone_Air_Temperature_Setpoint": {},
+                        "Occupied_Zone_Air_Temperature_Setpoint": {},
+                        "Unoccupied_Zone_Air_Temperature_Setpoint": {},
+                        "Zone_Air_Cooling_Temperature_Setpoint": {},
+                        "Zone_Air_Heating_Temperature_Setpoint": {}
+                    },
+                    "Discharge_Air_Temperature_Setpoint": {
+                        "Effective_Discharge_Air_Temperature_Setpoint": {},
+                        "Occupied_Discharge_Air_Temperature_Setpoint": {},
+                        "Unoccupied_Discharge_Air_Temperature_Setpoint": {},
+                        "Discharge_Air_Temperature_Cooling_Setpoint": {
+                            "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {}
+                        },
+                        "Discharge_Air_Temperature_Heating_Setpoint": {
+                            "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {}
+                        },
+                        "Discharge_Air_Temperature_Deadband_Setpoint": {
+                            "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {},
+                            "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {}
+                        }
+                    },
+                    "Effective_Air_Temperature_Setpoint": {
+                        "Effective_Air_Temperature_Cooling_Setpoint": {},
+                        "Effective_Air_Temperature_Heating_Setpoint": {},
+                        "Effective_Return_Air_Temperature_Setpoint": {},
+                        "Effective_Room_Air_Temperature_Setpoint": {},
+                        "Effective_Supply_Air_Temperature_Setpoint": {},
+                        "Effective_Zone_Air_Temperature_Setpoint": {},
+                        "Effective_Discharge_Air_Temperature_Setpoint": {}
+                    },
+                    "Occupied_Air_Temperature_Setpoint": {
+                        "Occupied_Air_Temperature_Cooling_Setpoint": {},
+                        "Occupied_Air_Temperature_Heating_Setpoint": {},
+                        "Occupied_Return_Air_Temperature_Setpoint": {},
+                        "Occupied_Room_Air_Temperature_Setpoint": {},
+                        "Occupied_Supply_Air_Temperature_Setpoint": {},
+                        "Occupied_Zone_Air_Temperature_Setpoint": {},
+                        "Occupied_Discharge_Air_Temperature_Setpoint": {}
+                    },
+                    "Unoccupied_Air_Temperature_Setpoint": {
+                        "Unoccupied_Air_Temperature_Cooling_Setpoint": {},
+                        "Unoccupied_Air_Temperature_Heating_Setpoint": {},
+                        "Unoccupied_Return_Air_Temperature_Setpoint": {},
+                        "Unoccupied_Room_Air_Temperature_Setpoint": {},
+                        "Unoccupied_Supply_Air_Temperature_Setpoint": {},
+                        "Unoccupied_Zone_Air_Temperature_Setpoint": {},
+                        "Unoccupied_Discharge_Air_Temperature_Setpoint": {}
+                    }
                 }
             },
-            "Voltage_Sensor": {},
-            "Water_Level_Sensor": {},
-            "Imbalance_Sensor": {},
-            "Position_Sensor": {},
-            "Conductivity_Sensor": {},
-            "Speed_Sensor": {},
-            "Generation_Sensor": {},
-            "Energy_Sensor": {
-                "Electric_Energy_Sensor": {}
-            },
-            "Dewpoint_Sensor": {},
-            "Humidity_Sensor": {
-                "Relative_Humidity_Sensor": {}
-            },
-            "Usage_Sensor": {
-                "Water_Usage_Sensor": {}
-            },
-            "Current_Sensor": {
-                "Current_Output_Sensor": {}
-            },
-            "Torque_Sensor": {},
-            "Duration_Sensor": {},
-            "Frequency_Sensor": {},
-            "Enthalpy_Sensor": {
-                "Air_Enthalpy_Sensor": {}
-            },
-            "Air_Grains_Sensor": {},
-            "Illuminance_Sensor": {},
-            "Motion_Sensor": {},
-            "Angle_Sensor": {},
-            "Adjust_Sensor": {},
-            "Heat_Sensor": {},
-            "Direction_Sensor": {}
+            "Humidity_Setpoint": {
+                "Building_Air_Humidity_Setpoint": {},
+                "Bypass_Air_Humidity_Setpoint": {},
+                "Exhaust_Air_Humidity_Setpoint": {},
+                "Mixed_Air_Humidity_Setpoint": {},
+                "Occupied_Humidity_Setpoint": {},
+                "Outside_Air_Humidity_Setpoint": {},
+                "Return_Air_Humidity_Setpoint": {},
+                "Supply_Air_Humidity_Setpoint": {},
+                "Unoccupied_Humidity_Setpoint": {},
+                "Zone_Air_Humidity_Setpoint": {},
+                "Discharge_Air_Humidity_Setpoint": {}
+            }
         },
         "Alarm": {
+            "Change_Filter_Alarm": {},
+            "Communication_Loss_Alarm": {},
+            "Liquid_Detection_Alarm": {},
+            "Low_Battery_Alarm": {},
+            "Luminance_Alarm": {},
+            "Maintenance_Required_Alarm": {},
+            "Overload_Alarm": {},
+            "Valve_Position_Alarm": {},
+            "CO2_Alarm": {
+                "High_CO2_Alarm": {}
+            },
+            "Cycle_Alarm": {
+                "Short_Cycle_Alarm": {}
+            },
+            "Emergency_Alarm": {
+                "Emergency_Generator_Alarm": {}
+            },
+            "Leak_Alarm": {
+                "Condensate_Leak_Alarm": {}
+            },
+            "Power_Alarm": {
+                "Power_Loss_Alarm": {}
+            },
+            "Smoke_Alarm": {
+                "Smoke_Detection_Alarm": {
+                    "Supply_Air_Smoke_Detection_Alarm": {},
+                    "Discharge_Air_Smoke_Detection_Alarm": {}
+                }
+            },
+            "Voltage_Alarm": {
+                "Low_Voltage_Alarm": {}
+            },
+            "Failure_Alarm": {
+                "Sensor_Failure_Alarm": {},
+                "Unit_Failure_Alarm": {}
+            },
+            "Humidity_Alarm": {
+                "High_Humidity_Alarm": {},
+                "Low_Humidity_Alarm": {}
+            },
+            "Pressure_Alarm": {
+                "High_Head_Pressure_Alarm": {},
+                "Low_Suction_Pressure_Alarm": {}
+            },
             "Air_Alarm": {
+                "Supply_Air_Smoke_Detection_Alarm": {},
+                "Discharge_Air_Smoke_Detection_Alarm": {},
                 "Air_Flow_Alarm": {
-                    "Low_Air_Flow_Alarm": {}
+                    "Air_Flow_Loss_Alarm": {},
+                    "High_Air_Flow_Alarm": {},
+                    "Low_Air_Flow_Alarm": {
+                        "Low_Supply_Air_Flow_Alarm": {},
+                        "Low_Discharge_Air_Flow_Alarm": {}
+                    }
                 },
                 "Air_Temperature_Alarm": {
-                    "Discharge_Air_Temperature_Alarm": {}
+                    "Return_Air_Temperature_Alarm": {
+                        "High_Return_Air_Temperature_Alarm": {},
+                        "Low_Return_Air_Temperature_Alarm": {}
+                    },
+                    "Supply_Air_Temperature_Alarm": {
+                        "High_Supply_Air_Temperature_Alarm": {},
+                        "Low_Supply_Air_Temperature_Alarm": {}
+                    },
+                    "Discharge_Air_Temperature_Alarm": {
+                        "High_Discharge_Air_Temperature_Alarm": {},
+                        "Low_Discharge_Air_Temperature_Alarm": {}
+                    }
+                }
+            },
+            "Temperature_Alarm": {
+                "Water_Temperature_Alarm": {
+                    "Entering_Water_Temperature_Alarm": {},
+                    "Leaving_Water_Temperature_Alarm": {}
+                },
+                "Air_Temperature_Alarm": {
+                    "Return_Air_Temperature_Alarm": {
+                        "High_Return_Air_Temperature_Alarm": {},
+                        "Low_Return_Air_Temperature_Alarm": {}
+                    },
+                    "Supply_Air_Temperature_Alarm": {
+                        "High_Supply_Air_Temperature_Alarm": {},
+                        "Low_Supply_Air_Temperature_Alarm": {}
+                    },
+                    "Discharge_Air_Temperature_Alarm": {
+                        "High_Discharge_Air_Temperature_Alarm": {},
+                        "Low_Discharge_Air_Temperature_Alarm": {}
+                    }
+                },
+                "High_Temperature_Alarm": {
+                    "High_Return_Air_Temperature_Alarm": {},
+                    "High_Supply_Air_Temperature_Alarm": {},
+                    "High_Discharge_Air_Temperature_Alarm": {}
+                },
+                "Low_Temperature_Alarm": {
+                    "Low_Return_Air_Temperature_Alarm": {},
+                    "Low_Supply_Air_Temperature_Alarm": {},
+                    "Low_Discharge_Air_Temperature_Alarm": {}
                 }
             },
             "Water_Alarm": {
-                "Water_Level_Alarm": {}
-            },
-            "Leak_Alarm": {},
-            "Emergency_Alarm": {},
-            "Temperature_Alarm": {
-                "Water_Temperature_Alarm": {},
-                "High_Temperature_Alarm": {},
-                "Low_Temperature_Alarm": {}
-            },
-            "CO2_Alarm": {},
-            "Pressure_Alarm": {},
-            "Humidity_Alarm": {},
-            "Voltage_Alarm": {},
-            "Power_Alarm": {},
-            "Failure_Alarm": {},
-            "Cycle_Alarm": {},
-            "Smoke_Alarm": {}
-        },
-        "Parameter": {
-            "Delay_Parameter": {},
-            "Alarm_Sensitivity_Parameter": {},
-            "PID_Parameter": {
-                "Time_Parameter": {
-                    "Integral_Time_Parameter": {
-                        "Differential_Pressure_Integral_Time_Parameter": {},
-                        "Air_Temperature_Integral_Time_Parameter": {},
-                        "Exhaust_Air_Flow_Integral_Time_Parameter": {},
-                        "Static_Pressure_Integral_Time_Parameter": {}
-                    }
+                "Deionized_Water_Alarm": {},
+                "No_Water_Alarm": {},
+                "Water_Loss_Alarm": {},
+                "Water_Temperature_Alarm": {
+                    "Entering_Water_Temperature_Alarm": {},
+                    "Leaving_Water_Temperature_Alarm": {}
                 },
-                "Proportional_Band_Parameter": {
-                    "Differential_Pressure_Proportional_Band": {},
-                    "Supply_Air_Temperature_Proportional_Band_Parameter": {},
-                    "Exhaust_Air_Flow_Proportional_Band_Parameter": {},
-                    "Static_Pressure_Proportional_Band_Parameter": {},
-                    "Discharge_Air_Temperature_Proportional_Band_Parameter": {}
-                },
-                "Step_Parameter": {
-                    "Differential_Pressure_Step_Parameter": {},
-                    "Static_Pressure_Step_Parameter": {
-                        "Air_Static_Pressure_Step_Parameter": {}
-                    },
-                    "Temperature_Step_Parameter": {
-                        "Air_Temperature_Step_Parameter": {}
-                    }
-                },
-                "Gain_Parameter": {
-                    "Integral_Gain_Parameter": {},
-                    "Proportional_Gain_Parameter": {}
+                "Water_Level_Alarm": {
+                    "Collection_Basin_Water_Level_Alarm": {},
+                    "Max_Water_Level_Alarm": {},
+                    "Min_Water_Level_Alarm": {}
                 }
-            },
-            "Limit": {
-                "Static_Pressure_Setpoint_Limit": {},
-                "Differential_Pressure_Setpoint_Limit": {},
-                "Fresh_Air_Setpoint_Limit": {},
-                "Air_Flow_Setpoint_Limit": {
-                    "Max_Air_Flow_Setpoint_Limit": {
-                        "Max_Cooling_Supply_Air_Flow_Setpoint_Limit": {},
-                        "Max_Heating_Supply_Air_Flow_Setpoint_Limit": {},
-                        "Max_Cooling_Discharge_Air_Flow_Setpoint_Limit": {},
-                        "Max_Heating_Discharge_Air_Flow_Setpoint_Limit": {}
-                    },
-                    "Min_Air_Flow_Setpoint_Limit": {
-                        "Min_Cooling_Supply_Air_Flow_Setpoint_Limit": {},
-                        "Min_Heating_Supply_Air_Flow_Setpoint_Limit": {},
-                        "Min_Cooling_Discharge_Air_Flow_Setpoint_Limit": {},
-                        "Min_Heating_Discharge_Air_Flow_Setpoint_Limit": {}
-                    }
-                },
-                "Max_Limit": {
-                    "Max_Temperature_Setpoint_Limit": {}
-                },
-                "Min_Limit": {
-                    "Min_Temperature_Setpoint_Limit": {}
-                },
-                "Air_Temperature_Setpoint_Limit": {
-                    "Discharge_Air_Temperature_Setpoint_Limit": {}
-                }
-            },
-            "Humidity_Parameter": {},
-            "Temperature_Parameter": {
-                "Lockout_Temperature_Differential_Parameter": {
-                    "Outside_Air_Lockout_Temperature_Differential_Parameter": {}
-                }
-            },
-            "Load_Parameter": {}
+            }
         },
         "Command": {
-            "Mode_Command": {},
-            "Enable_Command": {
-                "System_Enable_Command": {
-                    "Hot_Water_System_Enable_Command": {}
+            "Boiler_Command": {},
+            "Bypass_Command": {},
+            "Cooling_Command": {},
+            "Direction_Command": {},
+            "Heating_Command": {},
+            "Humidify_Command": {},
+            "Lead_Lag_Command": {},
+            "Light_Command": {},
+            "Luminance_Command": {},
+            "Occupancy_Command": {},
+            "Preheat_Command": {},
+            "Pump_Command": {},
+            "Relay_Command": {},
+            "Speed_Command": {},
+            "Tint_Command": {},
+            "Damper_Command": {
+                "Damper_Position_Command": {}
+            },
+            "Fan_Command": {
+                "Fan_Speed_Command": {}
+            },
+            "Override_Command": {
+                "Curtailment_Override_Command": {}
+            },
+            "Valve_Command": {
+                "Valve_Position_Command": {}
+            },
+            "Frequency_Command": {
+                "Max_Frequency_Command": {},
+                "Min_Frequency_Command": {}
+            },
+            "Position_Command": {
+                "Damper_Position_Command": {},
+                "Valve_Position_Command": {}
+            },
+            "Load_Shed_Command": {
+                "Occupied_Load_Shed_Command": {
+                    "Zone_Occupied_Load_Shed_Command": {}
+                },
+                "Standby_Load_Shed_Command": {
+                    "Zone_Standby_Load_Shed_Command": {}
+                },
+                "Unoccupied_Load_Shed_Command": {
+                    "Zone_Unoccupied_Load_Shed_Command": {}
                 }
             },
-            "Override_Command": {},
-            "Damper_Command": {},
-            "Disable_Command": {},
-            "Fan_Command": {},
-            "Reset_Command": {},
-            "On_Off_Command": {},
-            "Frequency_Command": {},
-            "Position_Command": {},
-            "Load_Shed_Command": {
-                "Occupied_Load_Shed_Command": {},
-                "Standby_Load_Shed_Command": {},
-                "Unoccupied_Load_Shed_Command": {}
+            "Mode_Command": {
+                "Automatic_Mode_Command": {},
+                "Box_Mode_Command": {},
+                "Maintenance_Mode_Command": {}
+            },
+            "Reset_Command": {
+                "Fault_Reset_Command": {},
+                "Filter_Reset_Command": {},
+                "Speed_Reset_Command": {}
+            },
+            "Disable_Command": {
+                "Disable_Differential_Enthalpy_Command": {},
+                "Disable_Differential_Temperature_Command": {},
+                "Disable_Fixed_Enthalpy_Command": {},
+                "Disable_Fixed_Temperature_Command": {}
+            },
+            "On_Off_Command": {
+                "Lead_On_Off_Command": {},
+                "Off_Command": {},
+                "On_Command": {},
+                "Start_Stop_Command": {},
+                "Steam_On_Off_Command": {}
+            },
+            "Enable_Command": {
+                "Cooling_Enable_Command": {},
+                "Enable_Differential_Enthalpy_Command": {},
+                "Enable_Differential_Temperature_Command": {},
+                "Enable_Fixed_Enthalpy_Command": {},
+                "Enable_Fixed_Temperature_Command": {},
+                "Heating_Enable_Command": {},
+                "Run_Enable_Command": {},
+                "Stage_Enable_Command": {},
+                "VFD_Enable_Command": {},
+                "System_Enable_Command": {
+                    "Chilled_Water_System_Enable_Command": {},
+                    "Hot_Water_System_Enable_Command": {
+                        "Domestic_Hot_Water_System_Enable_Command": {}
+                    }
+                }
             }
         },
         "Status": {
+            "Availability_Status": {},
+            "Damper_Position_Status": {},
+            "Disable_Status": {},
+            "Drive_Ready_Status": {},
+            "Emergency_Generator_Status": {},
+            "Emergency_Push_Button_Status": {},
+            "Even_Month_Status": {},
+            "Freeze_Status": {},
+            "Hold_Status": {},
+            "Lead_Lag_Status": {},
+            "Lockout_Status": {},
+            "Manual_Auto_Status": {},
+            "Open_Close_Status": {},
+            "Pump_Status": {},
+            "Stages_Status": {},
+            "Switch_Status": {},
+            "System_Shutdown_Status": {},
+            "Thermostat_Status": {},
+            "Tint_Status": {},
+            "Valve_Status": {},
+            "Direction_Status": {
+                "Motor_Direction_Status": {}
+            },
+            "Enable_Status": {
+                "Heat_Exchanger_System_Enable_Status": {}
+            },
+            "Fan_Status": {
+                "Fan_On_Off_Status": {}
+            },
+            "Filter_Status": {
+                "Pre_Filter_Status": {}
+            },
+            "Occupancy_Status": {
+                "Temporary_Occupancy_Status": {}
+            },
+            "Speed_Status": {
+                "Speed_Mode_Status": {}
+            },
+            "Fault_Status": {
+                "Humidifier_Fault_Status": {},
+                "Last_Fault_Code_Status": {}
+            },
+            "On_Status": {
+                "Overridden_On_Status": {},
+                "On_Off_Status": {
+                    "Fan_On_Off_Status": {},
+                    "Locally_On_Off_Status": {},
+                    "Motor_On_Off_Status": {},
+                    "Pump_On_Off_Status": {},
+                    "Remotely_On_Off_Status": {},
+                    "Standby_Unit_On_Off_Status": {
+                        "Standby_Glycool_Unit_On_Off_Status": {}
+                    },
+                    "Start_Stop_Status": {
+                        "Cooling_Start_Stop_Status": {},
+                        "Dehumidification_Start_Stop_Status": {},
+                        "EconCycle_Start_Stop_Status": {},
+                        "Heating_Start_Stop_Status": {},
+                        "Humidification_Start_Stop_Status": {},
+                        "Run_Status": {
+                            "Run_Request_Status": {}
+                        }
+                    }
+                }
+            },
+            "Overridden_Status": {
+                "Overridden_Off_Status": {},
+                "Overridden_On_Status": {}
+            },
             "Load_Shed_Status": {
-                "Differential_Pressure_Load_Shed_Status": {
-                    "Chilled_Water_Differential_Pressure_Load_Shed_Status": {},
-                    "Hot_Water_Differential_Pressure_Load_Shed_Status": {},
-                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status": {}
+                "Entering_Hot_Water_Temperature_Load_Shed_Status": {
+                    "Entering_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Status": {}
                 },
-                "Entering_Hot_Water_Temperature_Load_Shed_Status": {},
-                "Leaving_Hot_Water_Temperature_Load_Shed_Status": {}
+                "Leaving_Hot_Water_Temperature_Load_Shed_Status": {
+                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Status": {}
+                },
+                "Differential_Pressure_Load_Shed_Status": {
+                    "Chilled_Water_Differential_Pressure_Load_Shed_Status": {
+                        "Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status": {}
+                    },
+                    "Hot_Water_Differential_Pressure_Load_Shed_Status": {
+                        "Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {}
+                    },
+                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status": {
+                        "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {}
+                    }
+                }
             },
             "Off_Status": {
-                "On_Off_Status": {
-                    "Start_Stop_Status": {
-                        "Run_Status": {}
-                    },
-                    "Standby_Unit_On_Off_Status": {}
+                "Overridden_Off_Status": {},
+                "Emergency_Power_Off_System_Status": {
+                    "Emergency_Power_Off_System_Activated_By_High_Temperature_Status": {},
+                    "Emergency_Power_Off_System_Activated_By_Leak_Detection_System_Status": {}
                 },
-                "Emergency_Power_Off_System_Status": {}
+                "On_Off_Status": {
+                    "Fan_On_Off_Status": {},
+                    "Locally_On_Off_Status": {},
+                    "Motor_On_Off_Status": {},
+                    "Pump_On_Off_Status": {},
+                    "Remotely_On_Off_Status": {},
+                    "Standby_Unit_On_Off_Status": {
+                        "Standby_Glycool_Unit_On_Off_Status": {}
+                    },
+                    "Start_Stop_Status": {
+                        "Cooling_Start_Stop_Status": {},
+                        "Dehumidification_Start_Stop_Status": {},
+                        "EconCycle_Start_Stop_Status": {},
+                        "Heating_Start_Stop_Status": {},
+                        "Humidification_Start_Stop_Status": {},
+                        "Run_Status": {
+                            "Run_Request_Status": {}
+                        }
+                    }
+                }
             },
-            "System_Status": {},
-            "Fan_Status": {},
-            "Enable_Status": {},
-            "Fault_Status": {},
-            "Direction_Status": {},
+            "Pressure_Status": {
+                "Supply_Air_Duct_Pressure_Status": {},
+                "Discharge_Air_Duct_Pressure_Status": {},
+                "Differential_Pressure_Load_Shed_Status": {
+                    "Chilled_Water_Differential_Pressure_Load_Shed_Status": {
+                        "Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status": {}
+                    },
+                    "Hot_Water_Differential_Pressure_Load_Shed_Status": {
+                        "Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {}
+                    },
+                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status": {
+                        "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {}
+                    }
+                }
+            },
+            "System_Status": {
+                "Emergency_Air_Flow_System_Status": {},
+                "Heat_Exchanger_System_Enable_Status": {},
+                "System_Shutdown_Status": {},
+                "Emergency_Power_Off_System_Status": {
+                    "Emergency_Power_Off_System_Activated_By_High_Temperature_Status": {},
+                    "Emergency_Power_Off_System_Activated_By_Leak_Detection_System_Status": {}
+                }
+            },
             "Mode_Status": {
-                "Cooling_Mode_Status": {},
-                "Heating_Mode_Status": {},
-                "Operating_Mode_Status": {}
+                "Speed_Mode_Status": {},
+                "Zone_Air_Conditioning_Mode_Status": {},
+                "Operating_Mode_Status": {
+                    "Vent_Operating_Mode_Status": {}
+                },
+                "Cooling_Mode_Status": {
+                    "Occupied_Cooling_Mode_Status": {},
+                    "Unoccupied_Cooling_Mode_Status": {}
+                },
+                "Heating_Mode_Status": {
+                    "Occupied_Heating_Mode_Status": {},
+                    "Unoccupied_Heating_Mode_Status": {}
+                },
+                "Occupied_Mode_Status": {
+                    "Occupied_Cooling_Mode_Status": {},
+                    "Occupied_Heating_Mode_Status": {}
+                },
+                "Unoccupied_Mode_Status": {
+                    "Unoccupied_Cooling_Mode_Status": {},
+                    "Unoccupied_Heating_Mode_Status": {}
+                }
             },
-            "On_Status": {},
-            "Filter_Status": {},
-            "Pressure_Status": {},
-            "Occupancy_Status": {}
+            "On_Off_Status": {
+                "Fan_On_Off_Status": {},
+                "Locally_On_Off_Status": {},
+                "Motor_On_Off_Status": {},
+                "Pump_On_Off_Status": {},
+                "Remotely_On_Off_Status": {},
+                "Standby_Unit_On_Off_Status": {
+                    "Standby_Glycool_Unit_On_Off_Status": {}
+                },
+                "Start_Stop_Status": {
+                    "Cooling_Start_Stop_Status": {},
+                    "Dehumidification_Start_Stop_Status": {},
+                    "EconCycle_Start_Stop_Status": {},
+                    "Heating_Start_Stop_Status": {},
+                    "Humidification_Start_Stop_Status": {},
+                    "Run_Status": {
+                        "Run_Request_Status": {}
+                    }
+                }
+            }
+        },
+        "Sensor": {
+            "Capacity_Sensor": {},
+            "Contact_Sensor": {},
+            "Fire_Sensor": {},
+            "Frost_Sensor": {},
+            "Gas_Sensor": {},
+            "Hail_Sensor": {},
+            "Luminance_Sensor": {},
+            "Occupancy_Count_Sensor": {},
+            "Occupancy_Sensor": {},
+            "Piezoelectric_Sensor": {},
+            "Power_Factor_Sensor": {},
+            "Rain_Level_Sensor": {},
+            "Refrigerant_Level_Sensor": {},
+            "Solar_Radiance_Sensor": {},
+            "Conductivity_Sensor": {
+                "Deionised_Water_Conductivity_Sensor": {}
+            },
+            "Direction_Sensor": {
+                "Wind_Direction_Sensor": {}
+            },
+            "Enthalpy_Sensor": {
+                "Air_Enthalpy_Sensor": {
+                    "Outside_Air_Enthalpy_Sensor": {},
+                    "Return_Air_Enthalpy_Sensor": {}
+                }
+            },
+            "Frequency_Sensor": {
+                "Output_Frequency_Sensor": {}
+            },
+            "Generation_Sensor": {
+                "Energy_Generation_Sensor": {}
+            },
+            "Heat_Sensor": {
+                "Trace_Heat_Sensor": {}
+            },
+            "Humidity_Sensor": {
+                "Relative_Humidity_Sensor": {
+                    "Exhaust_Air_Humidity_Sensor": {},
+                    "Mixed_Air_Humidity_Sensor": {},
+                    "Outside_Air_Humidity_Sensor": {},
+                    "Return_Air_Humidity_Sensor": {},
+                    "Supply_Air_Humidity_Sensor": {},
+                    "Zone_Air_Humidity_Sensor": {},
+                    "Discharge_Air_Humidity_Sensor": {}
+                }
+            },
+            "Illuminance_Sensor": {
+                "Outside_Illuminance_Sensor": {}
+            },
+            "Motion_Sensor": {
+                "PIR_Sensor": {}
+            },
+            "Torque_Sensor": {
+                "Motor_Torque_Sensor": {}
+            },
+            "Adjust_Sensor": {
+                "Temperature_Adjust_Sensor": {},
+                "Warm_Cool_Adjust_Sensor": {}
+            },
+            "Air_Grains_Sensor": {
+                "Outside_Air_Grains_Sensor": {},
+                "Return_Air_Grains_Sensor": {}
+            },
+            "Angle_Sensor": {
+                "Solar_Azimuth_Angle_Sensor": {},
+                "Solar_Zenith_Angle_Sensor": {}
+            },
+            "Energy_Sensor": {
+                "Energy_Usage_Sensor": {},
+                "Electric_Energy_Sensor": {
+                    "Reactive_Energy_Sensor": {}
+                }
+            },
+            "Imbalance_Sensor": {
+                "Current_Imbalance_Sensor": {},
+                "Voltage_Imbalance_Sensor": {}
+            },
+            "Power_Sensor": {
+                "Thermal_Power_Sensor": {
+                    "Heating_Thermal_Power_Sensor": {}
+                },
+                "Electric_Power_Sensor": {
+                    "Active_Power_Sensor": {},
+                    "Reactive_Power_Sensor": {}
+                }
+            },
+            "Water_Level_Sensor": {
+                "Collection_Basin_Water_Level_Sensor": {},
+                "Deionised_Water_Level_Sensor": {}
+            },
+            "Current_Sensor": {
+                "Load_Current_Sensor": {},
+                "Motor_Current_Sensor": {},
+                "Current_Output_Sensor": {
+                    "Photovoltaic_Current_Output_Sensor": {},
+                    "PV_Current_Output_Sensor": {}
+                }
+            },
+            "Demand_Sensor": {
+                "Peak_Demand_Sensor": {},
+                "Cooling_Demand_Sensor": {
+                    "Average_Cooling_Demand_Sensor": {}
+                },
+                "Heating_Demand_Sensor": {
+                    "Average_Heating_Demand_Sensor": {}
+                }
+            },
+            "Duration_Sensor": {
+                "On_Timer_Sensor": {},
+                "Rain_Duration_Sensor": {},
+                "Run_Time_Sensor": {}
+            },
+            "Flow_Sensor": {
+                "Natural_Gas_Flow_Sensor": {},
+                "Air_Flow_Sensor": {
+                    "Bypass_Air_Flow_Sensor": {},
+                    "Fume_Hood_Air_Flow_Sensor": {},
+                    "Mixed_Air_Flow_Sensor": {},
+                    "Outside_Air_Flow_Sensor": {},
+                    "Return_Air_Flow_Sensor": {},
+                    "Exhaust_Air_Flow_Sensor": {
+                        "Exhaust_Air_Stack_Flow_Sensor": {}
+                    },
+                    "Supply_Air_Flow_Sensor": {
+                        "Average_Supply_Air_Flow_Sensor": {}
+                    },
+                    "Discharge_Air_Flow_Sensor": {
+                        "Average_Discharge_Air_Flow_Sensor": {}
+                    }
+                },
+                "Water_Flow_Sensor": {
+                    "Bypass_Water_Flow_Sensor": {},
+                    "Entering_Water_Flow_Sensor": {
+                        "Entering_Chilled_Water_Flow_Sensor": {},
+                        "Entering_Condenser_Water_Flow_Sensor": {},
+                        "Entering_Hot_Water_Flow_Sensor": {}
+                    },
+                    "Leaving_Water_Flow_Sensor": {
+                        "Leaving_Chilled_Water_Flow_Sensor": {},
+                        "Leaving_Condenser_Water_Flow_Sensor": {},
+                        "Leaving_Hot_Water_Flow_Sensor": {}
+                    },
+                    "Condenser_Water_Flow_Sensor": {
+                        "Leaving_Condenser_Water_Flow_Sensor": {},
+                        "Discharge_Condenser_Water_Flow_Sensor": {},
+                        "Return_Condenser_Water_Flow_Sensor": {},
+                        "Supply_Condenser_Water_Flow_Sensor": {}
+                    },
+                    "Discharge_Water_Flow_Sensor": {
+                        "Chilled_Water_Discharge_Flow_Sensor": {},
+                        "Discharge_Condenser_Water_Flow_Sensor": {},
+                        "Hot_Water_Discharge_Flow_Sensor": {}
+                    },
+                    "Return_Water_Flow_Sensor": {
+                        "Chilled_Water_Return_Flow_Sensor": {},
+                        "Hot_Water_Return_Flow_Sensor": {},
+                        "Return_Condenser_Water_Flow_Sensor": {}
+                    },
+                    "Supply_Water_Flow_Sensor": {
+                        "Chilled_Water_Supply_Flow_Sensor": {},
+                        "Hot_Water_Supply_Flow_Sensor": {},
+                        "Supply_Condenser_Water_Flow_Sensor": {}
+                    },
+                    "Chilled_Water_Flow_Sensor": {
+                        "Entering_Chilled_Water_Flow_Sensor": {},
+                        "Leaving_Chilled_Water_Flow_Sensor": {},
+                        "Chilled_Water_Discharge_Flow_Sensor": {},
+                        "Chilled_Water_Return_Flow_Sensor": {},
+                        "Chilled_Water_Supply_Flow_Sensor": {}
+                    },
+                    "Hot_Water_Flow_Sensor": {
+                        "Entering_Hot_Water_Flow_Sensor": {},
+                        "Leaving_Hot_Water_Flow_Sensor": {},
+                        "Hot_Water_Discharge_Flow_Sensor": {},
+                        "Hot_Water_Return_Flow_Sensor": {},
+                        "Hot_Water_Supply_Flow_Sensor": {}
+                    }
+                }
+            },
+            "Position_Sensor": {
+                "Damper_Position_Sensor": {},
+                "Sash_Position_Sensor": {},
+                "Valve_Position_Sensor": {}
+            },
+            "Pressure_Sensor": {
+                "Velocity_Pressure_Sensor": {
+                    "Exhaust_Air_Velocity_Pressure_Sensor": {},
+                    "Supply_Air_Velocity_Pressure_Sensor": {},
+                    "Discharge_Air_Velocity_Pressure_Sensor": {}
+                },
+                "Differential_Pressure_Sensor": {
+                    "Chilled_Water_Differential_Pressure_Sensor": {},
+                    "Filter_Differential_Pressure_Sensor": {},
+                    "Hot_Water_Differential_Pressure_Sensor": {
+                        "Medium_Temperature_Hot_Water_Differential_Pressure_Sensor": {}
+                    },
+                    "Air_Differential_Pressure_Sensor": {
+                        "Exhaust_Air_Differential_Pressure_Sensor": {},
+                        "Return_Air_Differential_Pressure_Sensor": {},
+                        "Supply_Air_Differential_Pressure_Sensor": {},
+                        "Discharge_Air_Differential_Pressure_Sensor": {}
+                    }
+                },
+                "Static_Pressure_Sensor": {
+                    "Building_Air_Static_Pressure_Sensor": {},
+                    "Supply_Air_Static_Pressure_Sensor": {},
+                    "Underfloor_Air_Plenum_Static_Pressure_Sensor": {},
+                    "Discharge_Air_Static_Pressure_Sensor": {},
+                    "Exhaust_Air_Static_Pressure_Sensor": {
+                        "Average_Exhaust_Air_Static_Pressure_Sensor": {},
+                        "Lowest_Exhaust_Air_Static_Pressure_Sensor": {}
+                    }
+                }
+            },
+            "Speed_Sensor": {
+                "Differential_Speed_Sensor": {},
+                "Motor_Speed_Sensor": {},
+                "Wind_Speed_Sensor": {}
+            },
+            "Voltage_Sensor": {
+                "Battery_Voltage_Sensor": {},
+                "DC_Bus_Voltage_Sensor": {},
+                "Output_Voltage_Sensor": {}
+            },
+            "Usage_Sensor": {
+                "Energy_Usage_Sensor": {},
+                "Natural_Gas_Usage_Sensor": {},
+                "Steam_Usage_Sensor": {},
+                "Water_Usage_Sensor": {
+                    "Hot_Water_Usage_Sensor": {}
+                }
+            },
+            "Dewpoint_Sensor": {
+                "Exhaust_Air_Dewpoint_Sensor": {},
+                "Outside_Air_Dewpoint_Sensor": {},
+                "Return_Air_Dewpoint_Sensor": {},
+                "Supply_Air_Dewpoint_Sensor": {},
+                "Zone_Air_Dewpoint_Sensor": {},
+                "Discharge_Air_Dewpoint_Sensor": {}
+            },
+            "Temperature_Sensor": {
+                "Frost_Sensor": {},
+                "Heat_Sink_Temperature_Sensor": {},
+                "Natural_Gas_Temperature_Sensor": {},
+                "Soil_Temperature_Sensor": {},
+                "Air_Wet_Bulb_Temperature_Sensor": {
+                    "Outside_Air_Wet_Bulb_Temperature_Sensor": {}
+                },
+                "Radiant_Panel_Temperature_Sensor": {
+                    "Inside_Face_Surface_Temperature_Sensor": {},
+                    "Outside_Face_Surface_Temperature_Sensor": {},
+                    "Embedded_Temperature_Sensor": {
+                        "Core_Temperature_Sensor": {}
+                    }
+                },
+                "Air_Temperature_Sensor": {
+                    "Exhaust_Air_Temperature_Sensor": {},
+                    "Mixed_Air_Temperature_Sensor": {},
+                    "Return_Air_Temperature_Sensor": {},
+                    "Underfloor_Air_Temperature_Sensor": {},
+                    "Air_Wet_Bulb_Temperature_Sensor": {
+                        "Outside_Air_Wet_Bulb_Temperature_Sensor": {}
+                    },
+                    "Supply_Air_Temperature_Sensor": {
+                        "Preheat_Supply_Air_Temperature_Sensor": {}
+                    },
+                    "Discharge_Air_Temperature_Sensor": {
+                        "Preheat_Discharge_Air_Temperature_Sensor": {}
+                    },
+                    "Outside_Air_Temperature_Sensor": {
+                        "Intake_Air_Temperature_Sensor": {},
+                        "Outside_Air_Wet_Bulb_Temperature_Sensor": {},
+                        "Outside_Air_Temperature_Enable_Differential_Sensor": {
+                            "Low_Outside_Air_Temperature_Enable_Differential_Sensor": {}
+                        }
+                    },
+                    "Zone_Air_Temperature_Sensor": {
+                        "Average_Zone_Air_Temperature_Sensor": {},
+                        "Coldest_Zone_Air_Temperature_Sensor": {},
+                        "Warmest_Zone_Air_Temperature_Sensor": {}
+                    }
+                },
+                "Water_Temperature_Sensor": {
+                    "Collection_Basin_Water_Temperature_Sensor": {},
+                    "Entering_Water_Temperature_Sensor": {},
+                    "Heat_Exchanger_Discharge_Water_Temperature_Sensor": {},
+                    "Heat_Exchanger_Supply_Water_Temperature_Sensor": {},
+                    "Leaving_Water_Temperature_Sensor": {
+                        "Heat_Exchanger_Leaving_Water_Temperature_Sensor": {},
+                        "Ice_Tank_Leaving_Water_Temperature_Sensor": {}
+                    },
+                    "Domestic_Hot_Water_Temperature_Sensor": {
+                        "Entering_Domestic_Hot_Water_Temperature_Sensor": {},
+                        "Leaving_Domestic_Hot_Water_Temperature_Sensor": {},
+                        "Domestic_Hot_Water_Discharge_Temperature_Sensor": {}
+                    },
+                    "Return_Water_Temperature_Sensor": {
+                        "Chilled_Water_Return_Temperature_Sensor": {},
+                        "Hot_Water_Return_Temperature_Sensor": {
+                            "High_Temperature_Hot_Water_Return_Temperature_Sensor": {},
+                            "Medium_Temperature_Hot_Water_Return_Temperature_Sensor": {}
+                        }
+                    },
+                    "Entering_Hot_Water_Temperature_Sensor": {
+                        "Entering_Domestic_Hot_Water_Temperature_Sensor": {},
+                        "Entering_High_Temperature_Hot_Water_Temperature_Sensor": {},
+                        "Entering_Medium_Temperature_Hot_Water_Temperature_Sensor": {},
+                        "Hot_Water_Differential_Temperature_Sensor": {}
+                    },
+                    "Leaving_Hot_Water_Temperature_Sensor": {
+                        "Hot_Water_Differential_Temperature_Sensor": {},
+                        "Leaving_Domestic_Hot_Water_Temperature_Sensor": {},
+                        "Leaving_High_Temperature_Hot_Water_Temperature_Sensor": {},
+                        "Leaving_Medium_Temperature_Hot_Water_Temperature_Sensor": {}
+                    },
+                    "Water_Differential_Temperature_Sensor": {
+                        "Chilled_Water_Differential_Temperature_Sensor": {},
+                        "Hot_Water_Differential_Temperature_Sensor": {},
+                        "Differential_Discharge_Return_Water_Temperature_Sensor": {},
+                        "Differential_Supply_Return_Water_Temperature_Sensor": {}
+                    },
+                    "Condenser_Water_Temperature_Sensor": {
+                        "Entering_Condenser_Water_Temperature_Sensor": {},
+                        "Leaving_Condenser_Water_Temperature_Sensor": {},
+                        "Discharge_Condenser_Water_Temperature_Sensor": {},
+                        "Return_Condenser_Water_Temperature_Sensor": {},
+                        "Supply_Condenser_Water_Temperature_Sensor": {}
+                    },
+                    "Discharge_Water_Temperature_Sensor": {
+                        "Chilled_Water_Discharge_Temperature_Sensor": {},
+                        "Discharge_Condenser_Water_Temperature_Sensor": {},
+                        "Discharge_Condenser_Water_Temperature_Setpoint": {},
+                        "Discharge_Hot_Water_Temperature_Setpoint": {
+                            "Domestic_Hot_Water_Discharge_Temperature_Setpoint": {}
+                        },
+                        "Hot_Water_Discharge_Temperature_Sensor": {
+                            "High_Temperature_Hot_Water_Discharge_Temperature_Sensor": {},
+                            "Medium_Temperature_Hot_Water_Discharge_Temperature_Sensor": {}
+                        }
+                    },
+                    "Chilled_Water_Temperature_Sensor": {
+                        "Chilled_Water_Differential_Temperature_Sensor": {},
+                        "Differential_Entering_Leaving_Water_Temperature_Sensor": {},
+                        "Entering_Chilled_Water_Temperature_Sensor": {},
+                        "Leaving_Chilled_Water_Temperature_Sensor": {},
+                        "Chilled_Water_Discharge_Temperature_Sensor": {},
+                        "Chilled_Water_Return_Temperature_Sensor": {},
+                        "Chilled_Water_Supply_Temperature_Sensor": {}
+                    },
+                    "Supply_Water_Temperature_Sensor": {
+                        "Chilled_Water_Supply_Temperature_Sensor": {},
+                        "Hot_Water_Supply_Flow_Setpoint": {},
+                        "Supply_Condenser_Water_Temperature_Sensor": {},
+                        "Supply_Condenser_Water_Temperature_Setpoint": {},
+                        "Supply_Hot_Water_Temperature_Setpoint": {
+                            "Domestic_Hot_Water_Supply_Temperature_Setpoint": {}
+                        },
+                        "Hot_Water_Supply_Temperature_Sensor": {
+                            "Domestic_Hot_Water_Supply_Temperature_Sensor": {},
+                            "High_Temperature_Hot_Water_Supply_Temperature_Sensor": {},
+                            "Medium_Temperature_Hot_Water_Supply_Temperature_Sensor": {}
+                        }
+                    }
+                }
+            },
+            "Air_Quality_Sensor": {
+                "Ammonia_Sensor": {},
+                "Formaldehyde_Level_Sensor": {},
+                "Methane_Level_Sensor": {},
+                "NO2_Level_Sensor": {},
+                "Ozone_Level_Sensor": {},
+                "Radioactivity_Concentration_Sensor": {
+                    "Radon_Concentration_Sensor": {}
+                },
+                "CO2_Sensor": {
+                    "CO2_Differential_Sensor": {},
+                    "CO2_Level_Sensor": {},
+                    "Outside_Air_CO2_Sensor": {},
+                    "Return_Air_CO2_Sensor": {}
+                },
+                "CO_Sensor": {
+                    "CO_Differential_Sensor": {},
+                    "CO_Level_Sensor": {},
+                    "Outside_Air_CO_Sensor": {},
+                    "Return_Air_CO_Sensor": {}
+                },
+                "Particulate_Matter_Sensor": {
+                    "PM10_Sensor": {
+                        "PM10_Level_Sensor": {}
+                    },
+                    "PM1_Sensor": {
+                        "PM1_Level_Sensor": {}
+                    },
+                    "PM2.5_Sensor": {
+                        "PM2.5_Level_Sensor": {}
+                    },
+                    "TVOC_Sensor": {
+                        "TVOC_Level_Sensor": {}
+                    }
+                }
+            }
+        }
+    },
+    "Equipment": {
+        "Elevator": {},
+        "Gas_Distribution": {},
+        "Relay": {},
+        "Steam_Distribution": {},
+        "Water_Distribution": {},
+        "Weather_Station": {},
+        "Camera": {
+            "Surveillance_Camera": {}
+        },
+        "Furniture": {
+            "Stage_Riser": {}
+        },
+        "Solar_Thermal_Collector": {
+            "PVT_Panel": {}
+        },
+        "Motor": {
+            "Variable_Frequency_Drive": {},
+            "VFD": {
+                "Fan_VFD": {},
+                "Heat_Wheel_VFD": {},
+                "Pump_VFD": {}
+            }
+        },
+        "Shading_Equipment": {
+            "Automatic_Tint_Window": {},
+            "Blind": {}
+        },
+        "Water_Heater": {
+            "Collection_Basin_Water_Heater": {},
+            "Boiler": {
+                "Electric_Boiler": {},
+                "Natural_Gas_Boiler": {
+                    "Condensing_Natural_Gas_Boiler": {},
+                    "Noncondensing_Natural_Gas_Boiler": {}
+                }
+            }
+        },
+        "Lighting_Equipment": {
+            "Interface": {
+                "Touchpanel": {},
+                "Switch": {
+                    "Dimmer": {}
+                }
+            },
+            "Lighting": {
+                "Luminaire": {},
+                "Luminaire_Driver": {}
+            }
+        },
+        "Safety_Equipment": {
+            "First_Aid_Kit": {},
+            "AED": {},
+            "Automated_External_Defibrillator": {},
+            "Emergency_Wash_Station": {
+                "Drench_Hose": {},
+                "Eye_Wash_Station": {},
+                "Safety_Shower": {}
+            }
+        },
+        "Security_Equipment": {
+            "Intrusion_Detection_Equipment": {},
+            "Access_Control_Equipment": {
+                "Access_Reader": {}
+            },
+            "Intercom_Equipment": {
+                "Emergency_Phone": {},
+                "Video_Intercom": {}
+            },
+            "Video_Surveillance_Equipment": {
+                "Surveillance_Camera": {},
+                "NVR": {},
+                "Network_Video_Recorder": {}
+            }
+        },
+        "PV_Panel": {
+            "PVT_Panel": {}
+        },
+        "Fire_Safety_Equipment": {
+            "Fire_Alarm": {},
+            "Fire_Alarm_Control_Panel": {},
+            "Fire_Control_Panel": {},
+            "Heat_Detector": {},
+            "Smoke_Detector": {},
+            "Manual_Fire_Alarm_Activation_Equipment": {
+                "Fire_Alarm_Manual_Call_Point": {},
+                "Fire_Alarm_Pull_Station": {}
+            }
+        },
+        "Valve": {
+            "Gas_Valve": {},
+            "Natural_Gas_Seismic_Shutoff_Valve": {},
+            "HVAC_Valve": {
+                "Chilled_Water_Valve": {},
+                "Condenser_Water_Valve": {},
+                "Makeup_Water_Valve": {}
+            },
+            "Water_Valve": {
+                "Chilled_Water_Valve": {},
+                "Condenser_Water_Valve": {},
+                "Makeup_Water_Valve": {},
+                "Thermostatic_Mixing_Valve": {},
+                "Hot_Water_Valve": {
+                    "Domestic_Hot_Water_Valve": {},
+                    "Preheat_Hot_Water_Valve": {}
+                }
+            }
+        },
+        "Electrical_Equipment": {
+            "Breaker_Panel": {},
+            "Bus_Riser": {},
+            "Disconnect_Switch": {},
+            "Inverter": {},
+            "Motor_Control_Center": {},
+            "PlugStrip": {},
+            "Switchgear": {},
+            "Transformer": {},
+            "Energy_Storage": {
+                "Battery": {}
+            }
+        },
+        "Meter": {
+            "Thermal_Power_Meter": {},
+            "Electrical_Meter": {
+                "Building_Electrical_Meter": {}
+            },
+            "Gas_Meter": {
+                "Building_Gas_Meter": {}
+            },
+            "Water_Meter": {
+                "Building_Water_Meter": {},
+                "Chilled_Water_Meter": {
+                    "Building_Chilled_Water_Meter": {}
+                },
+                "Hot_Water_Meter": {
+                    "Building_Hot_Water_Meter": {}
+                }
+            },
+            "Building_Meter": {
+                "Building_Chilled_Water_Meter": {},
+                "Building_Electrical_Meter": {},
+                "Building_Gas_Meter": {},
+                "Building_Hot_Water_Meter": {},
+                "Building_Water_Meter": {}
+            }
+        },
+        "HVAC_Equipment": {
+            "Compressor": {},
+            "Condenser": {},
+            "Cooling_Tower": {},
+            "Cooling_Valve": {},
+            "Dry_Cooler": {},
+            "Economizer": {},
+            "Fume_Hood": {},
+            "Humidifier": {},
+            "Space_Heater": {},
+            "Steam_Valve": {},
+            "Thermostat": {},
+            "Air_Handler_Unit": {},
+            "Air_Handling_Unit": {},
+            "CRAH": {},
+            "Cold_Deck": {},
+            "Computer_Room_Air_Conditioning": {},
+            "Computer_Room_Air_Handler": {},
+            "HX": {},
+            "Hot_Deck": {},
+            "Isolation_Valve": {
+                "Condenser_Water_Isolation_Valve": {}
+            },
+            "Pump": {
+                "Water_Pump": {
+                    "Chilled_Water_Pump": {},
+                    "Condenser_Water_Pump": {},
+                    "Hot_Water_Pump": {}
+                }
+            },
+            "Boiler": {
+                "Electric_Boiler": {},
+                "Natural_Gas_Boiler": {
+                    "Condensing_Natural_Gas_Boiler": {},
+                    "Noncondensing_Natural_Gas_Boiler": {}
+                }
+            },
+            "Bypass_Valve": {
+                "Condenser_Water_Bypass_Valve": {},
+                "Differential_Pressure_Bypass_Valve": {}
+            },
+            "CRAC": {
+                "Standby_CRAC": {}
+            },
+            "Air_Plenum": {
+                "Return_Air_Plenum": {},
+                "Discharge_Air_Plenum": {},
+                "Supply_Air_Plenum": {
+                    "Underfloor_Air_Plenum": {}
+                }
+            },
+            "Chiller": {
+                "Absorption_Chiller": {},
+                "Centrifugal_Chiller": {}
+            },
+            "HVAC_Valve": {
+                "Chilled_Water_Valve": {},
+                "Condenser_Water_Valve": {},
+                "Makeup_Water_Valve": {}
+            },
+            "Heating_Valve": {
+                "Reheat_Valve": {},
+                "Return_Heating_Valve": {},
+                "Hot_Water_Valve": {
+                    "Domestic_Hot_Water_Valve": {},
+                    "Preheat_Hot_Water_Valve": {}
+                }
+            },
+            "Heat_Exchanger": {
+                "Condenser_Heat_Exchanger": {},
+                "Evaporative_Heat_Exchanger": {},
+                "Heat_Wheel": {},
+                "Coil": {
+                    "Cooling_Coil": {
+                        "Chilled_Water_Coil": {},
+                        "Direct_Expansion_Cooling_Coil": {}
+                    },
+                    "Heating_Coil": {
+                        "Direct_Expansion_Heating_Coil": {},
+                        "Hot_Water_Coil": {}
+                    }
+                }
+            },
+            "Filter": {
+                "Final_Filter": {},
+                "Intake_Air_Filter": {},
+                "Mixed_Air_Filter": {},
+                "Pre_Filter": {},
+                "Return_Air_Filter": {}
+            },
+            "Damper": {
+                "Economizer_Damper": {},
+                "Exhaust_Damper": {},
+                "Mixed_Damper": {},
+                "Outside_Damper": {},
+                "Relief_Damper": {},
+                "Return_Damper": {}
+            },
+            "AHU": {
+                "PAU": {},
+                "DOAS": {},
+                "Dedicated_Outdoor_Air_System_Unit": {},
+                "Dual_Duct_Air_Handling_Unit": {},
+                "MAU": {},
+                "Makeup_Air_Unit": {},
+                "RTU": {},
+                "Rooftop_Unit": {},
+                "DDAHU": {}
+            },
+            "Fan": {
+                "Booster_Fan": {},
+                "Ceiling_Fan": {},
+                "Cooling_Tower_Fan": {},
+                "Exhaust_Fan": {},
+                "Outside_Fan": {},
+                "Relief_Fan": {},
+                "Return_Fan": {},
+                "Standby_Fan": {},
+                "Supply_Fan": {},
+                "Transfer_Fan": {},
+                "Discharge_Fan": {}
+            },
+            "Terminal_Unit": {
+                "Constant_Air_Volume_Box": {},
+                "Fan_Coil_Unit": {},
+                "Induction_Unit": {},
+                "CAV": {},
+                "FCU": {},
+                "VAV": {},
+                "Chilled_Beam": {
+                    "Active_Chilled_Beam": {},
+                    "Passive_Chilled_Beam": {}
+                },
+                "Variable_Air_Volume_Box": {
+                    "Variable_Air_Volume_Box_With_Reheat": {},
+                    "RVAV": {}
+                },
+                "Air_Diffuser": {
+                    "Displacement_Flow_Air_Diffuser": {},
+                    "Jet_Nozzle_Air_Diffuser": {},
+                    "Laminar_Flow_Air_Diffuser": {}
+                },
+                "Radiator": {
+                    "Electric_Radiator": {
+                        "Electric_Baseboard_Radiator": {}
+                    },
+                    "Hot_Water_Radiator": {
+                        "Hot_Water_Baseboard_Radiator": {}
+                    },
+                    "Steam_Radiator": {
+                        "Steam_Baseboard_Radiator": {}
+                    },
+                    "Baseboard_Radiator": {
+                        "Electric_Baseboard_Radiator": {},
+                        "Hot_Water_Baseboard_Radiator": {},
+                        "Steam_Baseboard_Radiator": {}
+                    }
+                },
+                "Radiant_Panel": {
+                    "Embedded_Surface_System_Panel": {},
+                    "Radiant_Ceiling_Panel": {},
+                    "Thermally_Activated_Building_System_Panel": {},
+                    "ESS_Panel": {},
+                    "RC_Panel": {},
+                    "TABS_Panel": {}
+                }
+            }
+        }
+    },
+    "Location": {
+        "Outside": {},
+        "Region": {},
+        "Storey": {},
+        "Wing": {},
+        "Site": {},
+        "Outdoor_Area": {
+            "Bench_Space": {},
+            "Field_Of_Play": {},
+            "Information_Area": {}
+        },
+        "Floor": {
+            "Basement": {},
+            "Parking_Level": {},
+            "Rooftop": {}
+        },
+        "Building": {
+            "Parking_Structure": {}
+        },
+        "Zone": {
+            "Energy_Zone": {},
+            "Fire_Zone": {},
+            "HVAC_Zone": {},
+            "Lighting_Zone": {}
+        },
+        "Space": {
+            "Entrance": {},
+            "Gatehouse": {},
+            "Media_Hot_Desk": {},
+            "Parking_Space": {},
+            "Ticketing_Booth": {},
+            "Tunnel": {},
+            "Water_Tank": {},
+            "Vertical_Space": {
+                "Riser": {},
+                "Staircase": {},
+                "Elevator_Shaft": {},
+                "Elevator_Space": {}
+            },
+            "Common_Space": {
+                "Atrium": {},
+                "Auditorium": {},
+                "Cafeteria": {},
+                "Hallway": {},
+                "Lounge": {
+                    "Majlis": {}
+                },
+                "Lobby": {
+                    "Employee_Entrance_Lobby": {},
+                    "Visitor_Lobby": {}
+                }
+            },
+            "Room": {
+                "Ablutions_Room": {},
+                "Conference_Room": {},
+                "Control_Room": {},
+                "Copy_Room": {},
+                "Exercise_Room": {},
+                "Hospitality_Box": {},
+                "Janitor_Room": {},
+                "Library": {},
+                "Loading_Dock": {},
+                "Mail_Room": {},
+                "Massage_Room": {},
+                "Office_Kitchen": {},
+                "Prayer_Room": {},
+                "Reception": {},
+                "Retail_Room": {},
+                "Server_Room": {},
+                "Shower": {},
+                "Sports_Service_Room": {},
+                "Wardrobe": {},
+                "Workshop": {},
+                "Break_Room": {},
+                "Breakroom": {},
+                "Food_Service_Room": {
+                    "Concession": {}
+                },
+                "Medical_Room": {
+                    "First_Aid_Room": {}
+                },
+                "Rest_Room": {},
+                "Restroom": {},
+                "Security_Service_Room": {
+                    "Detention_Room": {}
+                },
+                "Storage_Room": {
+                    "Hazardous_Materials_Storage": {},
+                    "Waste_Storage": {}
+                },
+                "Media_Room": {
+                    "Broadcast_Room": {},
+                    "Media_Production_Room": {},
+                    "Studio": {}
+                },
+                "Office": {
+                    "Cubicle": {},
+                    "Open_Office": {},
+                    "Enclosed_Office": {
+                        "Private_Office": {},
+                        "Shared_Office": {},
+                        "Team_Room": {}
+                    }
+                },
+                "Service_Room": {
+                    "Plumbing_Room": {},
+                    "Mechanical_Room": {
+                        "Pump_Room": {}
+                    },
+                    "Electrical_Room": {
+                        "Battery_Room": {},
+                        "Generator_Room": {},
+                        "Transformer_Room": {}
+                    }
+                },
+                "Laboratory": {
+                    "Cold_Box": {},
+                    "Environment_Box": {},
+                    "Freezer": {},
+                    "Hot_Box": {}
+                },
+                "Telecom_Room": {
+                    "Equipment_Room": {},
+                    "Switch_Room": {},
+                    "TETRA_Room": {},
+                    "Distribution_Frame": {
+                        "IDF": {},
+                        "MDF": {}
+                    }
+                }
+            }
         }
     },
     "Collection": {
+        "Portfolio": {},
+        "Photovoltaic_Array": {},
+        "PV_Array": {},
         "Loop": {
-            "Water_Loop": {}
+            "Air_Loop": {},
+            "Water_Loop": {
+                "Chilled_Water_Loop": {},
+                "Domestic_Water_Loop": {},
+                "Hot_Water_Loop": {}
+            }
         },
         "System": {
+            "Domestic_Hot_Water_System": {},
+            "Gas_System": {},
+            "Lighting_System": {},
             "Electrical_System": {
                 "Energy_System": {
-                    "Energy_Storage_System": {},
-                    "Energy_Generation_System": {}
+                    "Energy_Generation_System": {
+                        "PV_Generation_System": {}
+                    },
+                    "Energy_Storage_System": {
+                        "Battery_Energy_Storage_System": {}
+                    }
                 }
             },
-            "Shading_System": {},
-            "Heating_Ventilation_Air_Conditioning_System": {
-                "Water_System": {
-                    "Hot_Water_System": {}
-                },
-                "Air_System": {}
+            "HVAC_System": {},
+            "Shading_System": {
+                "Blind_Group": {}
             },
-            "Safety_System": {}
+            "Heating_Ventilation_Air_Conditioning_System": {
+                "Steam_System": {},
+                "Air_System": {
+                    "Ventilation_Air_System": {}
+                },
+                "Water_System": {
+                    "Chilled_Water_System": {},
+                    "Condenser_Water_System": {},
+                    "Hot_Water_System": {
+                        "Heat_Recovery_Hot_Water_System": {},
+                        "Preheat_Hot_Water_System": {},
+                        "Radiation_Hot_Water_System": {},
+                        "Reheat_Hot_Water_System": {}
+                    }
+                }
+            },
+            "Safety_System": {
+                "Emergency_Air_Flow_System": {},
+                "Emergency_Power_Off_System": {},
+                "Fire_Safety_System": {}
+            }
         }
     }
 }

--- a/brickllm/schemas.py
+++ b/brickllm/schemas.py
@@ -12,14 +12,26 @@ class RelationshipsSchema(BaseModel):
     relationships: List[Tuple[str, ...]]
 
 
+class EntityType(BaseModel):
+    ontology_concept: str = Field("The ontological concept")
+
+
+class Relationship(BaseModel):
+    relationship: str = Field("The relationship between the two entities")
+
+
 class Sensor(BaseModel):
     name: str = Field("name of the sensor")
-    uuid: Optional[str] = Field("Identifier of the sensor")
+    id: Optional[str] = Field("Identifier of the sensor")
     unit: Optional[str] = Field("Unit of measure of the sensor")
 
 
 class SensorSchema(BaseModel):
     sensors: List[Sensor] = Field("List of the sensors")
+
+
+class TriplesSchema(BaseModel):
+    triples: List[Tuple[str, ...]] = Field("List of tuples of type (str, str, str)")
 
 
 class TTLSchema(BaseModel):

--- a/brickllm/states.py
+++ b/brickllm/states.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from typing_extensions import TypedDict
+
+from rdflib import Graph
 
 from .schemas import Sensor
 
@@ -9,11 +11,9 @@ from .schemas import Sensor
 class State(TypedDict):
     user_prompt: str
     elem_list: List[str]
-    # elem_children_list: List[str]
     elem_hierarchy: Dict[str, Any]
-    # relationships: List[Tuple[str, str]]
-    rel_tree: Dict[str, Any]
-    sensors_dict: Dict[str, List[str]]
+    relationships: List[Tuple[str, str]]
+    graph :Graph
     is_sensor: bool
     is_valid: bool
     validation_report: str

--- a/brickllm/utils/__init__.py
+++ b/brickllm/utils/__init__.py
@@ -21,6 +21,7 @@ from .query_brickschema import (
     query_subclass,
     validate_ttl,
 )
+from .brick_constraints import find_rel_constraint, get_rel_definition, get_uom_dict
 from .rdf_parser import extract_rdf_graph
 from .ttl_to_prompt import ttl_to_building_prompt
 
@@ -46,4 +47,7 @@ __all__ = [
     "validate_ttl",
     "extract_rdf_graph",
     "ttl_to_building_prompt",
+    "get_rel_definition",
+    "find_rel_constraint",
+    "get_uom_dict",
 ]

--- a/brickllm/utils/brick_constraints.py
+++ b/brickllm/utils/brick_constraints.py
@@ -1,0 +1,179 @@
+import json
+from rdflib import Graph
+from typing import Dict
+import os
+import pkg_resources
+
+from brickllm.utils.get_hierarchy_info import find_parents
+from brickllm.utils.query_brickschema import get_query_result, general_query
+
+brick_ttl_path = pkg_resources.resource_filename(
+    __name__, os.path.join("..", "ontologies", "Brick.ttl")
+)
+# Load the Brick schema Turtle file
+g = Graph()
+g.parse(brick_ttl_path, format="ttl")
+
+hierarchy_path = pkg_resources.resource_filename(
+    __name__, os.path.join("..", "ontologies", "brick_hierarchy.json"))
+brick_hierarchy = json.load(open(hierarchy_path))
+
+
+def get_rel_definition() -> Dict:
+    """
+    Get the definition of all the relationship properties in the Brick schema.
+    Returns:
+        Dict: A dictionary containing the relationship properties and their definitions.
+
+    """
+
+    query = """
+    PREFIX owl: <http://www.w3.org/2002/07/owl#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    SELECT *
+    WHERE {
+        ?property a owl:AsymmetricProperty .
+        ?property skos:definition ?definition .
+    }
+    """
+
+    result = g.query(query)
+
+    properties = {}
+    for row in result:
+        property_name = row["property"].split("#")[-1]
+        properties[property_name] = {
+            "definition": str(row["definition"]),
+        }
+
+    return properties
+
+
+def find_rel_constraint(element: str) -> Dict:
+    """
+    Get the relationship constraints for a given element in the Brick schema. It extracts all the constraints of
+    all its parents.
+    Args:
+        element: the Brick class for which the relationship constraints are to be extracted.
+
+    Returns:
+        Dict: A dictionary containing the relationship constraints and the definition of the relationship for the given element.
+
+    """
+
+    definitions = get_rel_definition()
+    parent_list = find_parents(brick_hierarchy, element)[1]
+
+    query = """
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX brick: <https://brickschema.org/schema/Brick#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    SELECT ?path ?class
+    WHERE {{
+        brick:{element} sh:property ?property .
+        ?property sh:path ?path .
+        {{
+            ?property sh:class ?class .
+        }}
+        UNION
+        {{
+            ?property sh:or ?orList .
+            ?orList rdf:rest*/rdf:first ?nodeShape .
+            ?nodeShape sh:class ?class .
+        }}
+    }}
+    """
+
+    # Append the element to the parent list
+    elements = [element] + parent_list
+
+    property_dict = {}
+
+    for parent in elements:
+        property_list = []
+        query_res = get_query_result(query.format(element=parent))
+        for row in query_res:
+            property_list.append(row["path"].split("#")[-1])
+        property_list = list(set(property_list))
+
+        for property in property_list:
+            list_classes = []
+            for prop in query_res:
+                if prop["path"].split("#")[-1] == property:
+                    list_classes.append(prop["class"].split("#")[-1])
+            if property in property_dict:
+                for class_name in list_classes:
+                    if not class_name in property_dict[property]["constraints"]:
+                        property_dict[property]["constraints"].append(class_name)
+            else:
+                try:
+                    definition = definitions[property]["definition"]
+                except KeyError:
+                    definition = "No definition found"
+                property_dict[property] = {
+                    "definition": definition,
+                    "constraints": list_classes
+                }
+
+        if "Meter" in parent:
+            property_dict["meters"] = {
+                "definition": "the subject (of Meter class) meters the object.",
+                "constraints": ["Location", "Equipment", "HVAC_Equipment"]
+            }
+
+        if "Location" in elements or "Collection" in elements or "Equipment" in elements or "HVAC_Equipment" in elements:
+            property_dict["isMeteredBy"] = {
+                "definition": "the subject is recorded by the object.",
+                "constraints": ["Meter"]
+            }
+
+        if "Location" in elements:
+            property_dict["isLocationOf"] = {
+                "definition": "the subject is the location of the object.",
+                "constraints": ["Location", "Collection", "Equipment", "HVAC_Equipment"]
+            }
+
+    return property_dict
+
+
+def get_uom_dict(point_type_list) -> Dict:
+    """
+    Get the unit of measures for different Brick point types.
+    Args:
+        point_type_list: A list of Brick point types
+    Returns:
+        Dict: A dictionary containing the unit of measures for the given point types.
+
+    """
+    # Create a dictionary to store the unit of measures
+    uom_dict = {}
+
+    for point_type in point_type_list:
+        dict_type = {}
+        query = f"""
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX brick: <https://brickschema.org/schema/Brick#>
+        PREFIX qudt: <http://qudt.org/schema/qudt/>
+        PREFIX unit: <http://qudt.org/vocab/unit/>
+
+        SELECT ?quantity ?unit ?description
+        WHERE {{
+            brick:{point_type} brick:hasQuantity ?quantity .
+            ?quantity qudt:applicableUnit ?unit .
+            ?unit a qudt:Unit .
+            OPTIONAL {{ ?unit rdfs:label ?description . 
+                        }}
+        }}
+        """
+        res_query = g.query(query)
+        for row in res_query:
+            dict_type[str(row['unit']).split("/")[-1]] = {
+                "QUDT": str(row['unit']).split("/")[-1],
+                "description": str(row['description'])
+            }
+        uom_dict[point_type] = dict_type
+
+    return uom_dict

--- a/brickllm/utils/query_brickschema.py
+++ b/brickllm/utils/query_brickschema.py
@@ -205,7 +205,7 @@ def general_query(element: str) -> Dict[str, Dict[str, Union[str, List[str]]]]:
     return {"property": relationships}
 
 
-def validate_ttl(ttl_file: str, method: str = "pyshacl") -> Tuple[bool, str]:
+def validate_ttl(graph: Graph, method: str = "pyshacl") -> Tuple[bool, str]:
     """
     Validate a TTL file using the specified method.
 
@@ -216,19 +216,13 @@ def validate_ttl(ttl_file: str, method: str = "pyshacl") -> Tuple[bool, str]:
     Returns:
         Tuple[bool, str]: A tuple containing a boolean indicating if the validation was successful and a validation report or error message.
     """
-    # Load the ttl file
-    output_graph = Graph()
-    try:
-        output_graph.parse(StringIO(ttl_file), format="ttl")
-    except Exception as e:
-        return False, f"Failed to parse the TTL file. Content: {e}"
 
     if method == "pyshacl":
         valid, results_graph, report = pyshacl.validate(
-            output_graph,
+            data_graph=graph,
             shacl_graph=g,
             ont_graph=g,
-            inference="both",
+            inference="rdfs",
             abort_on_first=False,
             allow_infos=True,
             allow_warnings=True,

--- a/examples/example_custom_llm.py
+++ b/examples/example_custom_llm.py
@@ -7,16 +7,22 @@ load_dotenv()
 
 # Specify the user prompt
 building_description = """
-I have a building located in Bolzano.
-It has 3 floors and each floor has 1 office.
-There are 2 rooms in each office and each room has three sensors:
-- Temperature sensor;
-- Humidity sensor;
-- CO2 sensor.
+I have a building located that  is composed by 2 floors. 
+Each floor is composed by 1 room.
+The room at the first floor has three sensors:
+- Temperature sensor (°C) (ID: "hfws-xdf2");
+- Humidity sensor (ID: "regs-452z");
+- CO2 sensor (PPM) (ID: "gwq2-FH53).
+
+The room at the second floor has two sensors:
+- Temperature sensor (°C) (ID: "542c-743s");
+- CO2 sensor (PPM) (ID: "deqz-63sr).
+
+A general meter is installed in the building,  and collects the data of all the sensors in the building.
 """
 
 # Create an instance of BrickSchemaGraph with a custom model
-custom_model = ChatOpenAI(temperature=0, model="gpt-4o")
+custom_model = ChatOpenAI(temperature=0, model="gpt-4o-mini")
 brick_graph = BrickSchemaGraph(model=custom_model)
 
 # Display the graph structure
@@ -29,7 +35,7 @@ input_data = {"user_prompt": building_description}
 result = brick_graph.run(input_data=input_data, stream=False)
 
 # Print the result
-print(result)
+print(result["graph"].serialize())
 
 # save the result to a file
 brick_graph.save_ttl_output("my_building_custom.ttl")


### PR DESCRIPTION

## Overview

This pull request introduces a set of enhancements and structural improvements to the graph construction pipeline. The primary goals of this update are to increase robustness, reduce LLM hallucinations, improve the handling of Brick ontology relationships, and streamline the process of building RDF graphs from user input.

## Nodes

### get_elements

The logic in this node has been updated so that the LLM now identifies elements one category at a time, rather than all at once. After the LLM returns possible Brick categories based on the user prompt, a validation check ensures that the categories are indeed part of the Brick ontology. This step helps avoid hallucinated or invalid concepts being introduced into the graph.

### get_relationships

This node has been significantly expanded and now manages the full construction of the RDF graph. The entity extraction remains unchanged and continues to rely on the prompt. Once entities are identified, the node now assigns the correct Brick type to each entity. This step is a new addition and includes a retry mechanism that runs up to a maximum of three times in case of unrecognized or invalid results.

After type assignment, the node collects the constraints defined in the Brick ontology to determine which relationships between entities are valid. It then assigns relationships accordingly, again validating and retrying up to three times to ensure accuracy. Finally, the graph is constructed and returned as an RDF graph rather than a TTL string, providing a more structured and manipulable result. Additional checks have been introduced throughout this process to catch and mitigate hallucinated or invalid entities and relationships.

### get_sensors

This node now includes a pre-processing step to automatically detect if any of the entities in the RDF graph are subclasses of the `Point` class, without involving the LLM. If such sensors are detected, the LLM is then invoked to complete a dictionary containing the entity ID and associated unit of measure. It is worth noting that this dictionary should be refactored into a Pydantic model in a future update, in order to better support optional fields and provide a more structured interface.

### model_refactoring

In cases where the SHACL validation of the RDF graph fails, this node now attempts to refactor the model to address the validation errors. Unlike the `get_relationships` node, this one outputs a TTL string directly rather than an RDF object, as manipulating RDF graphs for refactoring is currently non-trivial.

## Utils

### brick_constraints

A new utility module has been introduced to provide a collection of functions for interacting with the Brick ontology. These functions are used primarily to identify valid constraints between entity types and their possible relationships.